### PR TITLE
Add demo web orchestrator, pin flow integration, and architecture docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,227 @@
+# Architecture
+
+## Purpose
+Privacy Protocol Toolkit for P2P is a Python-based system for verifying privacy
+properties over a real `py-libp2p` network. It combines:
+- libp2p proof exchange over `/privacyzk/1.0.0`
+- local SNARK verification for multiple privacy statements
+- network-level privacy analysis and reporting
+- optional verification-record pinning
+- an optional local dashboard that orchestrates the existing CLI
+
+The current implementation is a prototype and should not be treated as
+production-hardened infrastructure.
+
+## System Map
+```
+ ┌──────────────────┐
+ │   demo-web        │
+ │   dashboard       │
+ │   (orchestrator)  │
+ └────────┬─────────┘
+          │
+          ▼
+ ┌──────────────────┐       ┌──────────────────┐
+ │                   │──────▶│  privacyzk        │
+ │                   │       │  protocol         │
+ │                   │       │  network/privacyzk│
+ │                   │       └────────┬─────────┘
+ │      CLI          │                │
+ │     cli.py        │                ▼
+ │                   │       ┌──────────────────┐       ┌──────────────────┐
+ │                   │──────▶│  SNARK layer      │──────▶│  Proof assets    │
+ │                   │       │  privacy_protocol │       │  privacy_circuits│
+ │                   │       └──────────────────┘       │  /params         │
+ │                   │                                  └───────▲──────────┘
+ │                   │       ┌──────────────────┐               │
+ │                   │──────▶│  Analysis +       │       ┌──────┴───────────┐
+ │                   │       │  Reporting        │       │  Verification    │
+ │                   │       │  privacy_analyzer │       │  record pinning  │
+ │                   │       │  report_generator │       │  filecoin_pin    │
+ │                   │       └────────┬─────────┘       └──────────────────┘
+ │                   │                │                         ▲
+ │                   │                ▼                         │
+ │                   │       ┌──────────────────┐              │
+ │                   │       │  Reports +        │              │
+ │                   │       │  artifacts        │              │
+ │                   │       │  demo_reports/    │              │
+ │                   │       └──────────────────┘              │
+ │                   │─────────────────────────────────────────┘
+ └──────────────────┘
+
+ Edges:
+   UI ──▶ CLI ──▶ privacyzk ──▶ SNARK ──▶ Assets
+                                  ▲
+   CLI ──▶ SNARK (direct)  ───────┘
+   CLI ──▶ Analysis ──▶ Reports
+   CLI ──▶ PIN ──▶ Assets
+```
+
+## Core Components
+
+### CLI Surface
+Entry point: `<repo-root>/libp2p_privacy_poc/cli.py`
+
+The CLI is the main runtime surface. It exposes:
+- `zk-serve`: serves proof requests for remote peers
+- `zk-verify`: requests a statement proof from a remote peer and verifies it locally
+- `analyze`: captures live network activity and, when configured, requests proof verification
+- `zk-dial`: generates inbound traffic for analysis runs
+- `pin-proof-record`: verifies local assets and stores a verification record
+- `fetch-proof-record`: retrieves and optionally re-checks a stored verification record
+- `demo-web`: starts a local dashboard that drives the CLI workflow
+
+### Proof Exchange Layer
+Path: `<repo-root>/libp2p_privacy_poc/network/privacyzk/`
+
+This layer defines the `/privacyzk/1.0.0` request/response flow used between
+peers. It handles:
+- statement selection
+- request/response encoding
+- proof-serving integration
+- local verification after exchange
+
+### Privacy Protocol / SNARK Layer
+Path: `<repo-root>/libp2p_privacy_poc/privacy_protocol/`
+
+This layer contains the privacy statements and verification backends. In the
+current flow, the main statements are:
+- `membership`
+- `continuity`
+- `unlinkability`
+
+Real proving assets are resolved from `privacy_circuits/params/...`, using the
+canonical defaults documented in `docs/DEMO_CONTRACT.md`.
+
+### Analysis + Reporting
+Primary paths:
+- `<repo-root>/libp2p_privacy_poc/privacy_analyzer.py`
+- `<repo-root>/libp2p_privacy_poc/report_generator.py`
+- `<repo-root>/libp2p_privacy_poc/metadata_collector.py`
+
+This layer is separate from proof validity. It measures network behavior such
+as peer count, connection patterns, and timing signals, then produces:
+- console reports
+- JSON reports
+- reproducibility metadata
+- proof exchange summaries
+- actionable warnings
+
+### Verification Record Pinning
+Path: `<repo-root>/libp2p_privacy_poc/filecoin_pin/`
+
+This layer creates compact verification records from local proof artifacts,
+including statement metadata, hashes, verification result, and tool metadata.
+It supports:
+- pinning a record to an external pinning service
+- fetching a record back by CID
+- re-checking local assets against the fetched record
+
+### Optional Dashboard
+Path: `<repo-root>/libp2p_privacy_poc/demo_web/`
+
+The dashboard is an orchestration layer, not a separate protocol
+implementation. It starts and coordinates the existing CLI commands, captures
+artifacts, and renders:
+- proof status for all statements
+- proof exchange timings
+- network statistics and risk
+- record pin/fetch results
+- logs and output artifacts
+
+## Runtime Workflow
+```
+ ┌─────────────┐
+ │  zk-serve   │
+ └──────┬──────┘
+        ▼
+ ┌─────────────────────────────────┐
+ │  libp2p host listens on         │
+ │  /privacyzk/1.0.0               │◄──────── proof exchange ─────────┐
+ └─────────────────────────────────┘                                  │
+                                                                      │
+ ┌─────────────┐                    ┌─────────────┐                   │
+ │  zk-dial    │                    │  analyze     │                  │
+ └──────┬──────┘                    └──────┬──────┘                   │
+        ▼                                  ▼                          │
+ ┌──────────────────┐  peer    ┌──────────────────────┐               │
+ │  generate inbound │ traffic │  analyzer connects    │───────────────┘
+ │  peer traffic     │────────▶│  to proof server      │
+ └──────────────────┘          └───┬──────────────┬───┘
+                                   │              │
+                                   ▼              ▼
+                      ┌────────────────┐  ┌────────────────────┐
+                      │ request proofs │  │ network observations│
+                      │ membership     │  │ collected           │
+                      │ continuity     │  └─────────┬──────────┘
+                      │ unlinkability  │            │
+                      └───────┬────────┘            ▼
+                              │           ┌────────────────────┐
+                              ▼           │ privacy risk       │
+                      ┌───────────────┐   │ analysis           │
+                      │ local proof   │   └─────────┬──────────┘
+                      │ verification  │             │
+                      └───────┬───────┘             │
+                              ▼                     │
+                      ┌───────────────┐             │
+                      │ proof exchange│             │
+                      │ summary       │             │
+                      └───────┬───────┘             │
+                              │                     │
+                              ▼                     │
+                      ┌───────────────┐◄────────────┘
+                      │ report        │
+                      │ generation    │
+                      └───────────────┘
+
+ ┌──────────────────┐      ┌──────────────────────────────┐
+ │ pin-proof-record │─────▶│ verify local assets +        │
+ └──────────────────┘      │ pin verification record      │
+                           └──────────────┬───────────────┘
+                                          ▼
+                           ┌──────────────────────────────┐
+                           │ fetch-proof-record +         │
+                           │ optional recheck             │
+                           └──────────────────────────────┘
+```
+
+### Proof-Serving Path
+1. `zk-serve` starts a libp2p host and listens on a multiaddress.
+2. A remote peer requests one of the supported privacy statements.
+3. The server returns proof material and metadata for that statement.
+4. The requesting side verifies the proof locally before accepting the result.
+
+### Analysis Path
+1. `analyze` starts its own libp2p host and optionally connects to a proof-serving peer.
+2. `zk-dial` can generate additional inbound peers during the capture window.
+3. The analyzer records peer activity, timing, and connection counts.
+4. If `--zk-statement` is enabled, the analyzer requests proof verification from the target peer.
+5. The report combines:
+   - network privacy findings
+   - proof verification results
+   - reproducibility and artifact metadata
+
+### Verification Record Path
+1. `pin-proof-record` loads local proof assets for one or more statements.
+2. The tool verifies those assets locally.
+3. It builds a compact verification record and stores it through the configured pin backend.
+4. `fetch-proof-record` retrieves the record by CID and can re-check local assets against it.
+
+## Design Boundaries
+- Proof validity and network privacy risk are intentionally separate concerns.
+- The CLI is the source of truth; the dashboard wraps existing CLI behavior.
+- Real proof mode is asset-driven and depends on the expected params layout.
+- Pinning is additive and opt-in; existing proof flows do not depend on it.
+
+## Important Runtime Data
+- Proof assets: `<repo-root>/privacy_circuits/params/`
+- Local demo/report artifacts: `<repo-root>/demo_reports/`
+- Optional dashboard run artifacts: `<repo-root>/demo_reports/web/`
+
+## Repository Map
+- `<repo-root>/libp2p_privacy_poc/cli.py`: command entry point
+- `<repo-root>/libp2p_privacy_poc/network/privacyzk/`: proof exchange protocol
+- `<repo-root>/libp2p_privacy_poc/privacy_protocol/`: statement and SNARK logic
+- `<repo-root>/libp2p_privacy_poc/filecoin_pin/`: verification-record pin/fetch flow
+- `<repo-root>/libp2p_privacy_poc/demo_web/`: optional local orchestration dashboard
+- `<repo-root>/docs/DEMO_CONTRACT.md`: canonical defaults and demo contract

--- a/libp2p_privacy_poc/cli.py
+++ b/libp2p_privacy_poc/cli.py
@@ -1190,8 +1190,6 @@ def demo_web(
 ):
     """
     Start the local web dashboard for the end-to-end demo workflow.
-
-    Step 1 starts a minimal skeleton server; orchestration is added in later steps.
     """
     config = DemoWebConfig(
         host=host,
@@ -1209,9 +1207,8 @@ def demo_web(
         raise click.ClickException(str(exc)) from exc
 
     _configure_logging(config.log_level)
-    click.echo("Starting demo dashboard skeleton...")
+    click.echo("Starting demo dashboard...")
     click.echo(f"Open: http://{config.host}:{config.port}/")
-    click.echo("Warning: this is Step 1 skeleton; run orchestration is not yet enabled.")
     try:
         run_demo_server(config)
     except KeyboardInterrupt:

--- a/libp2p_privacy_poc/cli.py
+++ b/libp2p_privacy_poc/cli.py
@@ -31,6 +31,7 @@ from libp2p_privacy_poc.filecoin_pin import (
     pin_bytes,
     record_to_dict,
 )
+from libp2p_privacy_poc.demo_web import DemoWebConfig, run_demo_server
 from libp2p_privacy_poc.metadata_collector import MetadataCollector
 from libp2p_privacy_poc.privacy_analyzer import PrivacyAnalyzer
 from libp2p_privacy_poc.privacy_protocol.snark.backend import SnarkBackend
@@ -1115,6 +1116,106 @@ def zk_dial(peer, count, duration):
     except Exception as exc:
         click.echo(f"Dial failed: {_format_exception(exc)}", err=True)
         sys.exit(1)
+
+
+@main.command(name="demo-web")
+@click.option(
+    "--host",
+    type=str,
+    default="127.0.0.1",
+    show_default=True,
+    help="Dashboard listen host",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=8080,
+    show_default=True,
+    help="Dashboard listen port",
+)
+@click.option(
+    "--assets-dir",
+    type=click.Path(),
+    default="privacy_circuits/params",
+    show_default=True,
+    help="Base directory for verifier assets",
+)
+@click.option(
+    "--analyze-duration",
+    type=int,
+    default=20,
+    show_default=True,
+    help="Analysis capture duration in seconds",
+)
+@click.option(
+    "--zk-timeout",
+    type=int,
+    default=120,
+    show_default=True,
+    help="ZK request timeout in seconds",
+)
+@click.option(
+    "--traffic-nodes",
+    type=int,
+    default=12,
+    show_default=True,
+    help="Synthetic traffic dialer count (must be 8..13)",
+)
+@click.option(
+    "--pin-mode",
+    type=click.Choice(["prefer-live", "live", "mock"], case_sensitive=False),
+    default="prefer-live",
+    show_default=True,
+    help="Pin backend mode (skeleton wiring in this step)",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(
+        ["debug", "info", "warning", "error", "critical"],
+        case_sensitive=False,
+    ),
+    default="warning",
+    show_default=True,
+    help="Dashboard service logging level",
+)
+def demo_web(
+    host,
+    port,
+    assets_dir,
+    analyze_duration,
+    zk_timeout,
+    traffic_nodes,
+    pin_mode,
+    log_level,
+):
+    """
+    Start the local web dashboard for the end-to-end demo workflow.
+
+    Step 1 starts a minimal skeleton server; orchestration is added in later steps.
+    """
+    config = DemoWebConfig(
+        host=host,
+        port=port,
+        assets_dir=assets_dir,
+        analyze_duration=analyze_duration,
+        zk_timeout=zk_timeout,
+        traffic_nodes=traffic_nodes,
+        pin_mode=pin_mode.lower(),
+        log_level=log_level.lower(),
+    )
+    try:
+        config.validate()
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    _configure_logging(config.log_level)
+    click.echo("Starting demo dashboard skeleton...")
+    click.echo(f"Open: http://{config.host}:{config.port}/")
+    click.echo("Warning: this is Step 1 skeleton; run orchestration is not yet enabled.")
+    try:
+        run_demo_server(config)
+    except KeyboardInterrupt:
+        click.echo("\nStopping demo dashboard...")
 
 
 @main.command(name="pin-proof-record")

--- a/libp2p_privacy_poc/demo_web/__init__.py
+++ b/libp2p_privacy_poc/demo_web/__init__.py
@@ -1,0 +1,7 @@
+"""Minimal web demo wrapper for the CLI-based privacy protocol demo."""
+
+from .models import DemoWebConfig
+from .server import run_demo_server
+
+__all__ = ["DemoWebConfig", "run_demo_server"]
+

--- a/libp2p_privacy_poc/demo_web/models.py
+++ b/libp2p_privacy_poc/demo_web/models.py
@@ -1,0 +1,51 @@
+"""Data models for demo web server configuration and run state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class DemoWebConfig:
+    host: str = "127.0.0.1"
+    port: int = 8080
+    assets_dir: str = "privacy_circuits/params"
+    analyze_duration: int = 20
+    zk_timeout: int = 120
+    traffic_nodes: int = 12
+    pin_mode: str = "prefer-live"
+    log_level: str = "warning"
+
+    def validate(self) -> None:
+        if not self.host:
+            raise ValueError("host is required")
+        if self.port < 1 or self.port > 65535:
+            raise ValueError("port must be in range 1..65535")
+        if self.analyze_duration < 1:
+            raise ValueError("analyze-duration must be >= 1")
+        if self.zk_timeout < 1:
+            raise ValueError("zk-timeout must be >= 1")
+        if self.traffic_nodes < 8 or self.traffic_nodes > 13:
+            raise ValueError("traffic-nodes must be in range 8..13")
+        if self.pin_mode not in {"prefer-live", "live", "mock"}:
+            raise ValueError("pin-mode must be one of: prefer-live, live, mock")
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DemoRunState:
+    run_id: str
+    status: str
+    message: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {"run_id": self.run_id, "status": self.status, "message": self.message}
+
+
+def default_runs_dir() -> Path:
+    return Path("demo_reports") / "web"
+

--- a/libp2p_privacy_poc/demo_web/pin_mock.py
+++ b/libp2p_privacy_poc/demo_web/pin_mock.py
@@ -1,0 +1,20 @@
+"""Local pin-service mock placeholder (implemented in later steps)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PinMockServer:
+    host: str = "127.0.0.1"
+    port: int = 8787
+
+    def start(self) -> None:
+        """No-op placeholder for Step 1."""
+        return None
+
+    def stop(self) -> None:
+        """No-op placeholder for Step 1."""
+        return None
+

--- a/libp2p_privacy_poc/demo_web/pin_mock.py
+++ b/libp2p_privacy_poc/demo_web/pin_mock.py
@@ -1,20 +1,165 @@
-"""Local pin-service mock placeholder (implemented in later steps)."""
+"""Local in-process pin-service mock for demo fallback flows."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import base64
+import hashlib
+import json
+import threading
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Dict, Optional
+from urllib.parse import parse_qs, urlparse
+
+
+class _PinMockHTTPServer(ThreadingHTTPServer):
+    def __init__(self, server_address, handler_class, token: str):
+        super().__init__(server_address, handler_class)
+        self.token = token
+        self.store: Dict[str, bytes] = {}
+
+
+def _build_handler():
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/pin":
+                self._send_json({"error": "not found"}, status=HTTPStatus.NOT_FOUND)
+                return
+            if not self._auth_ok():
+                self._send_json({"error": "unauthorized"}, status=HTTPStatus.UNAUTHORIZED)
+                return
+            body = self._read_json()
+            if not isinstance(body, dict):
+                self._send_json(
+                    {"error": "invalid json body"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+
+            data_b64 = body.get("data_b64")
+            if not isinstance(data_b64, str):
+                self._send_json(
+                    {"error": "missing data_b64"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+            try:
+                payload = base64.b64decode(data_b64, validate=True)
+            except Exception:
+                self._send_json(
+                    {"error": "invalid data_b64"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+
+            cid = self._build_cid(payload)
+            self._mock_server().store[cid] = payload
+            self._send_json({"cid": cid}, status=HTTPStatus.OK)
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/fetch":
+                self._send_json({"error": "not found"}, status=HTTPStatus.NOT_FOUND)
+                return
+            if not self._auth_ok():
+                self._send_json({"error": "unauthorized"}, status=HTTPStatus.UNAUTHORIZED)
+                return
+
+            qs = parse_qs(parsed.query)
+            cid = (qs.get("cid") or [None])[0]
+            if not isinstance(cid, str) or not cid:
+                self._send_json(
+                    {"error": "missing cid"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+            payload = self._mock_server().store.get(cid)
+            if payload is None:
+                self._send_json(
+                    {"error": "cid not found"},
+                    status=HTTPStatus.NOT_FOUND,
+                )
+                return
+            self._send_json(
+                {"cid": cid, "data_b64": base64.b64encode(payload).decode("ascii")},
+                status=HTTPStatus.OK,
+            )
+
+        def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+            return None
+
+        def _auth_ok(self) -> bool:
+            header = self.headers.get("Authorization", "")
+            expected = f"Bearer {self._mock_server().token}"
+            return header == expected
+
+        def _read_json(self) -> Optional[dict]:
+            length_raw = self.headers.get("Content-Length", "")
+            try:
+                length = int(length_raw)
+            except ValueError:
+                return None
+            if length < 0:
+                return None
+            raw = self.rfile.read(length)
+            try:
+                payload = json.loads(raw.decode("utf-8"))
+            except Exception:
+                return None
+            return payload if isinstance(payload, dict) else None
+
+        def _send_json(self, payload: dict, status: HTTPStatus) -> None:
+            body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode(
+                "utf-8"
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        @staticmethod
+        def _build_cid(payload: bytes) -> str:
+            digest = hashlib.sha256(payload).hexdigest()
+            return f"bafy{digest[:56]}"
+
+        def _mock_server(self) -> _PinMockHTTPServer:
+            return self.server  # type: ignore[return-value]
+
+    return _Handler
 
 
 @dataclass
 class PinMockServer:
     host: str = "127.0.0.1"
-    port: int = 8787
+    port: int = 0
+    token: str = "demo-web-mock-token"
+    _server: Optional[_PinMockHTTPServer] = field(default=None, init=False, repr=False)
+    _thread: Optional[threading.Thread] = field(default=None, init=False, repr=False)
 
     def start(self) -> None:
-        """No-op placeholder for Step 1."""
-        return None
+        if self._server is not None:
+            return
+        handler_cls = _build_handler()
+        self._server = _PinMockHTTPServer((self.host, self.port), handler_cls, self.token)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
 
     def stop(self) -> None:
-        """No-op placeholder for Step 1."""
-        return None
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._thread = None
+        self._server = None
 
+    @property
+    def endpoint(self) -> str:
+        if self._server is None:
+            raise RuntimeError("pin mock server is not running")
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"

--- a/libp2p_privacy_poc/demo_web/runner.py
+++ b/libp2p_privacy_poc/demo_web/runner.py
@@ -1,0 +1,23 @@
+"""Run orchestration placeholder for web demo (implemented in later steps)."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from .models import DemoWebConfig
+
+
+class DemoRunner:
+    """Skeleton runner for the web dashboard."""
+
+    def __init__(self, config: DemoWebConfig) -> None:
+        self._config = config
+
+    def run_full_demo(self) -> Dict[str, Any]:
+        """Placeholder response for Step 1."""
+        return {
+            "status": "not_implemented",
+            "message": "Demo runner orchestration will be added in Step 2.",
+            "config": self._config.as_dict(),
+        }
+

--- a/libp2p_privacy_poc/demo_web/runner.py
+++ b/libp2p_privacy_poc/demo_web/runner.py
@@ -1,23 +1,378 @@
-"""Run orchestration placeholder for web demo (implemented in later steps)."""
+"""Run orchestration for web demo (Step 2 core flow)."""
 
 from __future__ import annotations
 
-from typing import Dict, Any
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
 
-from .models import DemoWebConfig
+from .models import DemoWebConfig, default_runs_dir
+
+SERVER_LISTEN_ADDR = "/ip4/127.0.0.1/tcp/50140"
+ANALYZE_LISTEN_ADDR = "/ip4/127.0.0.1/tcp/50158"
+FALLBACK_TEXT = "falling back to legacy simulation"
+
+_SERVER_MULTIADDR_RE = re.compile(r"^Listening:\s+(\S+/p2p/\S+)\s*$", re.MULTILINE)
+_ANALYZE_MULTIADDR_RE = re.compile(r"Listening on:\s+(\S+/p2p/\S+)")
+
+
+@dataclass(frozen=True)
+class RunArtifacts:
+    run_dir: Path
+    server_log: Path
+    analyze_log: Path
+    dial_log: Path
+    report_json: Path
+    summary_json: Path
+
+
+def extract_server_multiaddr(log_text: str) -> Optional[str]:
+    match = _SERVER_MULTIADDR_RE.search(log_text or "")
+    if not match:
+        return None
+    return match.group(1)
+
+
+def extract_analyzer_multiaddr(log_text: str) -> Optional[str]:
+    match = _ANALYZE_MULTIADDR_RE.search(log_text or "")
+    if not match:
+        return None
+    return match.group(1)
+
+
+def classify_run_status(core_error: bool, fallback_detected: bool) -> Tuple[str, str]:
+    if core_error:
+        return "failed", "Demo orchestration failed."
+    if fallback_detected:
+        return "fallback", "Fallback detected during analysis."
+    return "success", "Demo orchestration completed successfully."
 
 
 class DemoRunner:
-    """Skeleton runner for the web dashboard."""
+    """Run end-to-end orchestration for the dashboard backend."""
 
-    def __init__(self, config: DemoWebConfig) -> None:
+    def __init__(
+        self,
+        config: DemoWebConfig,
+        *,
+        root_dir: Optional[Path] = None,
+        python_executable: Optional[str] = None,
+    ) -> None:
         self._config = config
+        self._config.validate()
+        self._root_dir = root_dir or Path(__file__).resolve().parents[2]
+        self._runs_dir = self._root_dir / default_runs_dir()
+        self._runs_dir.mkdir(parents=True, exist_ok=True)
+        self._python = python_executable or self._infer_python_executable()
 
     def run_full_demo(self) -> Dict[str, Any]:
-        """Placeholder response for Step 1."""
-        return {
-            "status": "not_implemented",
-            "message": "Demo runner orchestration will be added in Step 2.",
-            "config": self._config.as_dict(),
-        }
+        run_id = self._make_run_id()
+        artifacts = self._create_run_artifacts(run_id)
+        sequence: list[str] = []
+        started_at = _utc_now()
 
+        server_proc: Optional[subprocess.Popen] = None
+        analyze_proc: Optional[subprocess.Popen] = None
+        dial_proc: Optional[subprocess.Popen] = None
+
+        server_multiaddr: Optional[str] = None
+        analyzer_multiaddr: Optional[str] = None
+        analyze_exit_code: Optional[int] = None
+        dial_exit_code: Optional[int] = None
+        fallback_detected = False
+        error: Optional[str] = None
+
+        try:
+            sequence.append("zk-serve")
+            server_proc = self._start_process(
+                self._build_zk_serve_cmd(),
+                artifacts.server_log,
+            )
+            server_multiaddr = self._wait_for_server_multiaddr(
+                artifacts.server_log,
+                timeout_seconds=25.0,
+                process=server_proc,
+            )
+            if not server_multiaddr:
+                raise RuntimeError("failed to parse server multiaddr from zk-serve output")
+
+            sequence.append("analyze")
+            analyze_proc = self._start_process(
+                self._build_analyze_cmd(server_multiaddr, artifacts.report_json),
+                artifacts.analyze_log,
+            )
+            analyzer_multiaddr = self._wait_for_analyzer_multiaddr(
+                artifacts.analyze_log,
+                timeout_seconds=25.0,
+                process=analyze_proc,
+            )
+            if not analyzer_multiaddr:
+                raise RuntimeError(
+                    "failed to parse analyzer multiaddr from analyze output"
+                )
+
+            sequence.append("zk-dial")
+            dial_proc = self._start_process(
+                self._build_zk_dial_cmd(analyzer_multiaddr),
+                artifacts.dial_log,
+            )
+
+            analyze_exit_code = analyze_proc.wait(
+                timeout=max(self._config.analyze_duration + self._config.zk_timeout + 30, 30)
+            )
+            dial_exit_code = dial_proc.wait(
+                timeout=max(self._config.analyze_duration + 30, 30)
+            )
+            fallback_detected = self._file_contains(
+                artifacts.analyze_log, FALLBACK_TEXT
+            )
+        except Exception as exc:  # pragma: no cover - defensive path
+            error = str(exc)
+        finally:
+            self._terminate_process(dial_proc)
+            self._terminate_process(analyze_proc)
+            self._terminate_process(server_proc)
+
+        core_error = bool(error)
+        if analyze_exit_code not in (None, 0):
+            core_error = True
+            error = error or f"analyze exited with code {analyze_exit_code}"
+        if dial_exit_code not in (None, 0):
+            core_error = True
+            error = error or f"zk-dial exited with code {dial_exit_code}"
+        if not artifacts.report_json.exists():
+            core_error = True
+            error = error or "analyze report.json missing"
+
+        status, message = classify_run_status(core_error, fallback_detected)
+        if error:
+            message = error
+
+        summary: Dict[str, Any] = {
+            "run_id": run_id,
+            "status": status,
+            "message": message,
+            "config": self._config.as_dict(),
+            "sequence": sequence,
+            "started_at": started_at,
+            "finished_at": _utc_now(),
+            "server_multiaddr": server_multiaddr,
+            "analyzer_multiaddr": analyzer_multiaddr,
+            "fallback_detected": fallback_detected,
+            "analyze_exit_code": analyze_exit_code,
+            "dial_exit_code": dial_exit_code,
+            "artifacts": {
+                "run_dir": str(artifacts.run_dir),
+                "server_log": str(artifacts.server_log),
+                "analyze_log": str(artifacts.analyze_log),
+                "dial_log": str(artifacts.dial_log),
+                "report_json": str(artifacts.report_json),
+                "summary_json": str(artifacts.summary_json),
+            },
+            "planned_steps": list(self.planned_step_names()),
+            "commands": {
+                "zk_serve": self._build_zk_serve_cmd(),
+                "analyze": self._build_analyze_cmd(
+                    server_multiaddr or "<missing-server-multiaddr>",
+                    artifacts.report_json,
+                ),
+                "zk_dial": self._build_zk_dial_cmd(
+                    analyzer_multiaddr or "<missing-analyzer-multiaddr>"
+                ),
+            },
+        }
+        self._write_json(artifacts.summary_json, summary)
+        return summary
+
+    @staticmethod
+    def planned_step_names() -> tuple[str, str, str]:
+        return ("zk-serve", "analyze", "zk-dial")
+
+    def _build_zk_serve_cmd(self) -> list[str]:
+        return [
+            self._python,
+            "-m",
+            "libp2p_privacy_poc.cli",
+            "--log-level",
+            self._config.log_level,
+            "zk-serve",
+            "--listen-addr",
+            SERVER_LISTEN_ADDR,
+            "--prove-mode",
+            "real",
+            "--assets-dir",
+            self._config.assets_dir,
+        ]
+
+    def _build_analyze_cmd(self, server_multiaddr: str, report_json: Path) -> list[str]:
+        return [
+            self._python,
+            "-m",
+            "libp2p_privacy_poc.cli",
+            "--log-level",
+            self._config.log_level,
+            "analyze",
+            "--duration",
+            str(self._config.analyze_duration),
+            "--listen-addr",
+            ANALYZE_LISTEN_ADDR,
+            "--connect-to",
+            server_multiaddr,
+            "--zk-peer",
+            server_multiaddr,
+            "--zk-statement",
+            "all",
+            "--zk-timeout",
+            str(self._config.zk_timeout),
+            "--zk-assets-dir",
+            self._config.assets_dir,
+            "--format",
+            "json",
+            "--output",
+            str(report_json),
+        ]
+
+    def _build_zk_dial_cmd(self, analyzer_multiaddr: str) -> list[str]:
+        return [
+            self._python,
+            "-m",
+            "libp2p_privacy_poc.cli",
+            "--log-level",
+            self._config.log_level,
+            "zk-dial",
+            "--peer",
+            analyzer_multiaddr,
+            "--count",
+            str(self._config.traffic_nodes),
+            "--duration",
+            str(max(self._config.analyze_duration + 2, 5)),
+        ]
+
+    def _create_run_artifacts(self, run_id: str) -> RunArtifacts:
+        run_dir = self._runs_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return RunArtifacts(
+            run_dir=run_dir,
+            server_log=run_dir / "zk_serve.log",
+            analyze_log=run_dir / "analyze.log",
+            dial_log=run_dir / "zk_dial.log",
+            report_json=run_dir / "report.json",
+            summary_json=run_dir / "summary.json",
+        )
+
+    def _start_process(self, cmd: list[str], log_path: Path) -> subprocess.Popen:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_file = log_path.open("w", encoding="utf-8")
+        env = self._base_env()
+        return subprocess.Popen(
+            cmd,
+            cwd=self._root_dir,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+        )
+
+    def _wait_for_server_multiaddr(
+        self,
+        log_path: Path,
+        *,
+        timeout_seconds: float,
+        process: Optional[subprocess.Popen],
+    ) -> Optional[str]:
+        return self._wait_for_multiaddr(
+            log_path,
+            extractor=extract_server_multiaddr,
+            timeout_seconds=timeout_seconds,
+            process=process,
+        )
+
+    def _wait_for_analyzer_multiaddr(
+        self,
+        log_path: Path,
+        *,
+        timeout_seconds: float,
+        process: Optional[subprocess.Popen],
+    ) -> Optional[str]:
+        return self._wait_for_multiaddr(
+            log_path,
+            extractor=extract_analyzer_multiaddr,
+            timeout_seconds=timeout_seconds,
+            process=process,
+        )
+
+    def _wait_for_multiaddr(
+        self,
+        log_path: Path,
+        *,
+        extractor,
+        timeout_seconds: float,
+        process: Optional[subprocess.Popen],
+    ) -> Optional[str]:
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            text = self._read_text(log_path)
+            addr = extractor(text)
+            if addr:
+                return addr
+            if process is not None and process.poll() is not None:
+                return None
+            time.sleep(0.1)
+        return None
+
+    @staticmethod
+    def _read_text(path: Path) -> str:
+        if not path.exists():
+            return ""
+        return path.read_text(encoding="utf-8", errors="replace")
+
+    @staticmethod
+    def _file_contains(path: Path, needle: str) -> bool:
+        text = DemoRunner._read_text(path)
+        return needle in text
+
+    @staticmethod
+    def _terminate_process(proc: Optional[subprocess.Popen]) -> None:
+        if proc is None:
+            return
+        if proc.poll() is not None:
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    @staticmethod
+    def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    @staticmethod
+    def _make_run_id() -> str:
+        now = datetime.now(timezone.utc)
+        return now.strftime("%Y%m%d-%H%M%S-%f")
+
+    def _infer_python_executable(self) -> str:
+        venv_python = self._root_dir / "venv" / "bin" / "python"
+        if venv_python.exists():
+            return str(venv_python)
+        return sys.executable
+
+    def _base_env(self) -> Dict[str, str]:
+        env = dict(os.environ)
+        env["PYTHONUNBUFFERED"] = "1"
+        return env
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )

--- a/libp2p_privacy_poc/demo_web/runner.py
+++ b/libp2p_privacy_poc/demo_web/runner.py
@@ -53,10 +53,10 @@ def extract_analyzer_multiaddr(log_text: str) -> Optional[str]:
 
 def classify_run_status(core_error: bool, fallback_detected: bool) -> Tuple[str, str]:
     if core_error:
-        return "failed", "Demo orchestration failed."
+        return "failed", "Orchestration failed."
     if fallback_detected:
         return "fallback", "Fallback detected during analysis."
-    return "success", "Demo orchestration completed successfully."
+    return "success", "Orchestration completed successfully."
 
 
 class DemoRunner:

--- a/libp2p_privacy_poc/demo_web/runner.py
+++ b/libp2p_privacy_poc/demo_web/runner.py
@@ -14,10 +14,12 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from .models import DemoWebConfig, default_runs_dir
+from .pin_mock import PinMockServer
 
 SERVER_LISTEN_ADDR = "/ip4/127.0.0.1/tcp/50140"
 ANALYZE_LISTEN_ADDR = "/ip4/127.0.0.1/tcp/50158"
 FALLBACK_TEXT = "falling back to legacy simulation"
+PIN_REQUIRED_ENV = ("FILECOIN_PIN_ENDPOINT", "FILECOIN_PIN_TOKEN")
 
 _SERVER_MULTIADDR_RE = re.compile(r"^Listening:\s+(\S+/p2p/\S+)\s*$", re.MULTILINE)
 _ANALYZE_MULTIADDR_RE = re.compile(r"Listening on:\s+(\S+/p2p/\S+)")
@@ -29,6 +31,8 @@ class RunArtifacts:
     server_log: Path
     analyze_log: Path
     dial_log: Path
+    pin_log: Path
+    fetch_log: Path
     report_json: Path
     summary_json: Path
 
@@ -88,6 +92,17 @@ class DemoRunner:
         dial_exit_code: Optional[int] = None
         fallback_detected = False
         error: Optional[str] = None
+        pin_data: Dict[str, Any] = {
+            "mode_requested": self._config.pin_mode,
+            "backend_used": None,
+            "fell_back_to_mock": False,
+            "live_error": None,
+            "error": None,
+            "pin_exit_code": None,
+            "fetch_exit_codes": {},
+            "pin_results": [],
+            "fetch_results": [],
+        }
 
         try:
             sequence.append("zk-serve")
@@ -133,6 +148,9 @@ class DemoRunner:
             fallback_detected = self._file_contains(
                 artifacts.analyze_log, FALLBACK_TEXT
             )
+
+            sequence.extend(["pin-proof-record", "fetch-proof-record"])
+            pin_data = self._run_pin_flow(artifacts, server_multiaddr)
         except Exception as exc:  # pragma: no cover - defensive path
             error = str(exc)
         finally:
@@ -150,6 +168,10 @@ class DemoRunner:
         if not artifacts.report_json.exists():
             core_error = True
             error = error or "analyze report.json missing"
+        pin_error = pin_data.get("error")
+        if isinstance(pin_error, str) and pin_error:
+            core_error = True
+            error = error or pin_error
 
         status, message = classify_run_status(core_error, fallback_detected)
         if error:
@@ -173,9 +195,12 @@ class DemoRunner:
                 "server_log": str(artifacts.server_log),
                 "analyze_log": str(artifacts.analyze_log),
                 "dial_log": str(artifacts.dial_log),
+                "pin_log": str(artifacts.pin_log),
+                "fetch_log": str(artifacts.fetch_log),
                 "report_json": str(artifacts.report_json),
                 "summary_json": str(artifacts.summary_json),
             },
+            "pin": pin_data,
             "planned_steps": list(self.planned_step_names()),
             "commands": {
                 "zk_serve": self._build_zk_serve_cmd(),
@@ -186,14 +211,26 @@ class DemoRunner:
                 "zk_dial": self._build_zk_dial_cmd(
                     analyzer_multiaddr or "<missing-analyzer-multiaddr>"
                 ),
+                "pin_proof_record": self._build_pin_proof_record_cmd(
+                    server_multiaddr or "<missing-server-multiaddr>"
+                ),
+                "fetch_proof_record_example": self._build_fetch_proof_record_cmd(
+                    "<cid>"
+                ),
             },
         }
         self._write_json(artifacts.summary_json, summary)
         return summary
 
     @staticmethod
-    def planned_step_names() -> tuple[str, str, str]:
-        return ("zk-serve", "analyze", "zk-dial")
+    def planned_step_names() -> tuple[str, str, str, str, str]:
+        return (
+            "zk-serve",
+            "analyze",
+            "zk-dial",
+            "pin-proof-record",
+            "fetch-proof-record",
+        )
 
     def _build_zk_serve_cmd(self) -> list[str]:
         return [
@@ -255,6 +292,42 @@ class DemoRunner:
             str(max(self._config.analyze_duration + 2, 5)),
         ]
 
+    def _build_pin_proof_record_cmd(self, server_multiaddr: str) -> list[str]:
+        return [
+            self._python,
+            "-m",
+            "libp2p_privacy_poc.cli",
+            "--log-level",
+            self._config.log_level,
+            "pin-proof-record",
+            "--statement",
+            "all",
+            "--assets-dir",
+            self._config.assets_dir,
+            "--schema",
+            "2",
+            "--prove-mode",
+            "real",
+            "--peer-multiaddr",
+            server_multiaddr,
+            "--json",
+        ]
+
+    def _build_fetch_proof_record_cmd(self, cid: str) -> list[str]:
+        return [
+            self._python,
+            "-m",
+            "libp2p_privacy_poc.cli",
+            "--log-level",
+            self._config.log_level,
+            "fetch-proof-record",
+            "--cid",
+            cid,
+            "--recheck-assets-dir",
+            self._config.assets_dir,
+            "--json",
+        ]
+
     def _create_run_artifacts(self, run_id: str) -> RunArtifacts:
         run_dir = self._runs_dir / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
@@ -263,6 +336,8 @@ class DemoRunner:
             server_log=run_dir / "zk_serve.log",
             analyze_log=run_dir / "analyze.log",
             dial_log=run_dir / "zk_dial.log",
+            pin_log=run_dir / "pin.log",
+            fetch_log=run_dir / "fetch.log",
             report_json=run_dir / "report.json",
             summary_json=run_dir / "summary.json",
         )
@@ -279,6 +354,271 @@ class DemoRunner:
             text=True,
             env=env,
         )
+
+    def _run_pin_flow(self, artifacts: RunArtifacts, server_multiaddr: str) -> Dict[str, Any]:
+        mode = self._config.pin_mode
+        if mode == "prefer-live":
+            live_result = self._run_pin_backend(
+                backend="live",
+                artifacts=artifacts,
+                server_multiaddr=server_multiaddr,
+            )
+            if not live_result["error"]:
+                return {
+                    **live_result,
+                    "mode_requested": mode,
+                    "fell_back_to_mock": False,
+                    "live_error": None,
+                }
+
+            mock_result = self._run_pin_backend(
+                backend="mock",
+                artifacts=artifacts,
+                server_multiaddr=server_multiaddr,
+            )
+            combined_error = mock_result["error"]
+            if combined_error:
+                combined_error = (
+                    f"live backend failed: {live_result['error']}; "
+                    f"mock backend failed: {combined_error}"
+                )
+            return {
+                **mock_result,
+                "mode_requested": mode,
+                "fell_back_to_mock": True,
+                "live_error": live_result["error"],
+                "error": combined_error,
+            }
+
+        result = self._run_pin_backend(
+            backend=mode,
+            artifacts=artifacts,
+            server_multiaddr=server_multiaddr,
+        )
+        return {
+            **result,
+            "mode_requested": mode,
+            "fell_back_to_mock": False,
+            "live_error": None,
+        }
+
+    def _run_pin_backend(
+        self,
+        *,
+        backend: str,
+        artifacts: RunArtifacts,
+        server_multiaddr: str,
+    ) -> Dict[str, Any]:
+        env = self._base_env()
+        mock_server: Optional[PinMockServer] = None
+        pin_results: list[Dict[str, Any]] = []
+        fetch_results: list[Dict[str, Any]] = []
+        fetch_exit_codes: Dict[str, int] = {}
+        pin_exit_code: Optional[int] = None
+
+        try:
+            if backend == "live":
+                self._require_live_pin_env(env)
+            elif backend == "mock":
+                mock_server = PinMockServer()
+                mock_server.start()
+                env["FILECOIN_PIN_ENDPOINT"] = mock_server.endpoint
+                env["FILECOIN_PIN_TOKEN"] = mock_server.token
+                env.setdefault("FILECOIN_PIN_TIMEOUT_SECONDS", "10")
+            else:
+                raise RuntimeError(f"unsupported pin backend: {backend}")
+
+            pin_payload, pin_exit_code = self._run_json_command(
+                self._build_pin_proof_record_cmd(server_multiaddr),
+                log_path=artifacts.pin_log,
+                env=env,
+                timeout_seconds=max(self._config.zk_timeout, 30),
+                append=False,
+            )
+            pin_results = self._normalize_pin_results(pin_payload)
+
+            fetch_errors: list[str] = []
+            for item in pin_results:
+                cid = item.get("cid")
+                if not isinstance(cid, str) or not cid:
+                    continue
+                fetch_payload, fetch_exit_code = self._run_json_command(
+                    self._build_fetch_proof_record_cmd(cid),
+                    log_path=artifacts.fetch_log,
+                    env=env,
+                    timeout_seconds=max(self._config.zk_timeout, 30),
+                    append=True,
+                )
+                fetch_exit_codes[cid] = fetch_exit_code
+                recheck = fetch_payload.get("recheck")
+                recheck_ok = (
+                    isinstance(recheck, dict) and recheck.get("ok") is True
+                )
+                fetch_record = {
+                    "cid": cid,
+                    "statement": item.get("statement"),
+                    "exit_code": fetch_exit_code,
+                    "recheck_ok": bool(recheck_ok),
+                }
+                fetch_results.append(fetch_record)
+                if fetch_exit_code != 0:
+                    fetch_errors.append(
+                        f"fetch-proof-record failed for {cid} (exit={fetch_exit_code})"
+                    )
+                elif not recheck_ok:
+                    fetch_errors.append(
+                        f"fetch-proof-record recheck failed for {cid}"
+                    )
+
+            statement_errors = [
+                item["error"]
+                for item in pin_results
+                if isinstance(item.get("error"), str) and item["error"]
+            ]
+
+            error: Optional[str] = None
+            if pin_exit_code != 0:
+                error = f"pin-proof-record exited with code {pin_exit_code}"
+            elif not pin_results:
+                error = "pin-proof-record returned no statement results"
+            elif statement_errors:
+                error = "; ".join(statement_errors)
+            elif fetch_errors:
+                error = "; ".join(fetch_errors)
+
+            return {
+                "backend_used": backend,
+                "error": error,
+                "pin_exit_code": pin_exit_code,
+                "fetch_exit_codes": fetch_exit_codes,
+                "pin_results": pin_results,
+                "fetch_results": fetch_results,
+            }
+        except Exception as exc:
+            self._append_log(
+                artifacts.pin_log,
+                f"[runner] pin backend {backend} failed: {exc}\n",
+            )
+            return {
+                "backend_used": backend,
+                "error": str(exc),
+                "pin_exit_code": pin_exit_code,
+                "fetch_exit_codes": fetch_exit_codes,
+                "pin_results": pin_results,
+                "fetch_results": fetch_results,
+            }
+        finally:
+            if mock_server is not None:
+                mock_server.stop()
+
+    def _run_json_command(
+        self,
+        cmd: list[str],
+        *,
+        log_path: Path,
+        env: Dict[str, str],
+        timeout_seconds: int,
+        append: bool,
+    ) -> Tuple[Dict[str, Any], int]:
+        completed = subprocess.run(
+            cmd,
+            cwd=self._root_dir,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout_seconds,
+        )
+        self._append_command_log(
+            log_path=log_path,
+            cmd=cmd,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            exit_code=completed.returncode,
+            append=append,
+        )
+        payload = self._parse_json_output(completed.stdout)
+        if not isinstance(payload, dict):
+            raise RuntimeError("command did not return a JSON object")
+        return payload, completed.returncode
+
+    @staticmethod
+    def _normalize_pin_results(payload: Dict[str, Any]) -> list[Dict[str, Any]]:
+        raw_results = payload.get("results")
+        if not isinstance(raw_results, list):
+            raise RuntimeError("pin-proof-record payload missing results[]")
+
+        normalized: list[Dict[str, Any]] = []
+        for item in raw_results:
+            if not isinstance(item, dict):
+                continue
+            normalized.append(
+                {
+                    "statement": item.get("statement"),
+                    "schema": item.get("schema"),
+                    "depth": item.get("depth"),
+                    "verify_ok": item.get("verify_ok"),
+                    "cid": item.get("cid"),
+                    "error": item.get("error"),
+                }
+            )
+        return normalized
+
+    def _require_live_pin_env(self, env: Dict[str, str]) -> None:
+        missing = [name for name in PIN_REQUIRED_ENV if not env.get(name, "").strip()]
+        if missing:
+            raise RuntimeError(
+                "live pin mode requires env vars: " + ", ".join(missing)
+            )
+
+    @staticmethod
+    def _parse_json_output(stdout: str) -> Dict[str, Any]:
+        stripped = (stdout or "").strip()
+        if not stripped:
+            raise RuntimeError("command returned empty stdout")
+        try:
+            payload = json.loads(stripped)
+            if isinstance(payload, dict):
+                return payload
+        except json.JSONDecodeError:
+            pass
+        for line in reversed(stripped.splitlines()):
+            candidate = line.strip()
+            if not candidate.startswith("{"):
+                continue
+            try:
+                payload = json.loads(candidate)
+                if isinstance(payload, dict):
+                    return payload
+            except json.JSONDecodeError:
+                continue
+        raise RuntimeError("failed to parse JSON from command output")
+
+    @staticmethod
+    def _append_command_log(
+        *,
+        log_path: Path,
+        cmd: list[str],
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+        append: bool,
+    ) -> None:
+        mode = "a" if append else "w"
+        with log_path.open(mode, encoding="utf-8") as handle:
+            if append:
+                handle.write("\n")
+            handle.write(f"$ {' '.join(cmd)}\n")
+            if stdout:
+                handle.write(stdout.rstrip("\n") + "\n")
+            if stderr:
+                handle.write("[stderr]\n")
+                handle.write(stderr.rstrip("\n") + "\n")
+            handle.write(f"[exit_code] {exit_code}\n")
+
+    @staticmethod
+    def _append_log(path: Path, text: str) -> None:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(text)
 
     def _wait_for_server_multiaddr(
         self,

--- a/libp2p_privacy_poc/demo_web/server.py
+++ b/libp2p_privacy_poc/demo_web/server.py
@@ -1,0 +1,80 @@
+"""Minimal HTTP server for the local web dashboard (Step 1 skeleton)."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Optional
+
+from .models import DemoWebConfig
+
+
+def run_demo_server(config: DemoWebConfig) -> None:
+    """Run the minimal dashboard server until interrupted."""
+    config.validate()
+    static_dir = Path(__file__).resolve().parent / "static"
+    handler_cls = _build_handler(config, static_dir)
+    server = ThreadingHTTPServer((config.host, config.port), handler_cls)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+def _build_handler(config: DemoWebConfig, static_dir: Path):
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path in ("/", "/index.html"):
+                self._send_file(static_dir / "index.html", "text/html; charset=utf-8")
+                return
+            if self.path == "/app.js":
+                self._send_file(
+                    static_dir / "app.js",
+                    "application/javascript; charset=utf-8",
+                )
+                return
+            if self.path == "/styles.css":
+                self._send_file(
+                    static_dir / "styles.css",
+                    "text/css; charset=utf-8",
+                )
+                return
+            if self.path == "/api/health":
+                payload = {
+                    "status": "ok",
+                    "mode": "skeleton",
+                    "config": config.as_dict(),
+                }
+                self._send_json(payload, status=HTTPStatus.OK)
+                return
+            self._send_json(
+                {"error": "not found", "path": self.path},
+                status=HTTPStatus.NOT_FOUND,
+            )
+
+        def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+            return None
+
+        def _send_file(self, path: Path, content_type: str) -> None:
+            if not path.exists() or not path.is_file():
+                self._send_json({"error": "file missing"}, status=HTTPStatus.NOT_FOUND)
+                return
+            data = path.read_bytes()
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _send_json(self, payload: dict, status: HTTPStatus) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return _Handler
+

--- a/libp2p_privacy_poc/demo_web/server.py
+++ b/libp2p_privacy_poc/demo_web/server.py
@@ -1,56 +1,281 @@
-"""Minimal HTTP server for the local web dashboard (Step 1 skeleton)."""
+"""HTTP server for the local judge-facing demo dashboard."""
 
 from __future__ import annotations
 
 import json
+import threading
+from datetime import datetime, timezone
+from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Dict, Optional, Tuple
+from urllib.parse import urlparse
 
 from .models import DemoWebConfig
+from .runner import DemoRunner
+
+_ALLOWED_LOGS = {
+    "server": "server_log",
+    "analyze": "analyze_log",
+    "dial": "dial_log",
+    "pin": "pin_log",
+    "fetch": "fetch_log",
+}
+
+_ALLOWED_ARTIFACTS = {
+    "report.json": "report_json",
+    "summary.json": "summary_json",
+}
+
+
+class DemoWebApp:
+    """In-memory run manager for dashboard API endpoints."""
+
+    def __init__(
+        self,
+        config: DemoWebConfig,
+        *,
+        runner_factory: Optional[Callable[[], DemoRunner]] = None,
+    ) -> None:
+        self._config = config
+        self._runner_factory = runner_factory or (lambda: DemoRunner(self._config))
+        self._lock = threading.Lock()
+        self._runs: Dict[str, Dict[str, Any]] = {}
+
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            run_count = len(self._runs)
+            active = sum(1 for run in self._runs.values() if run["status"] == "running")
+        return {
+            "status": "ok",
+            "mode": "dashboard",
+            "config": self._config.as_dict(),
+            "runs": {"total": run_count, "active": active},
+        }
+
+    def start_run(self) -> Dict[str, Any]:
+        run_id = _new_run_id()
+        record: Dict[str, Any] = {
+            "run_id": run_id,
+            "status": "running",
+            "message": "Run started",
+            "started_at": _utc_now(),
+            "finished_at": None,
+            "summary": None,
+            "thread": None,
+        }
+        with self._lock:
+            self._runs[run_id] = record
+
+        thread = threading.Thread(
+            target=self._run_worker,
+            args=(run_id,),
+            daemon=True,
+            name=f"demo-web-run-{run_id}",
+        )
+        record["thread"] = thread
+        thread.start()
+        return self.get_run_payload(run_id) or {
+            "run_id": run_id,
+            "status": "running",
+            "message": "Run started",
+        }
+
+    def get_run_payload(self, run_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            record = self._runs.get(run_id)
+            if record is None:
+                return None
+            payload = {
+                "run_id": record["run_id"],
+                "status": record["status"],
+                "message": record["message"],
+                "started_at": record["started_at"],
+                "finished_at": record["finished_at"],
+                "config": self._config.as_dict(),
+            }
+            summary = record.get("summary")
+
+        if summary:
+            payload["summary"] = summary
+            report = self._load_report(summary)
+            if report is not None:
+                payload["report"] = report
+        return payload
+
+    def resolve_log_path(self, run_id: str, name: str) -> Path:
+        return self._resolve_artifact_path(run_id, name, _ALLOWED_LOGS)
+
+    def resolve_artifact_path(self, run_id: str, name: str) -> Path:
+        return self._resolve_artifact_path(run_id, name, _ALLOWED_ARTIFACTS)
+
+    def _run_worker(self, run_id: str) -> None:
+        try:
+            summary = self._runner_factory().run_full_demo()
+            status = str(summary.get("status", "failed"))
+            message = str(summary.get("message", "Run finished"))
+        except Exception as exc:  # pragma: no cover - defensive
+            summary = None
+            status = "failed"
+            message = f"Runner error: {exc}"
+
+        with self._lock:
+            record = self._runs.get(run_id)
+            if record is None:
+                return
+            record["status"] = status
+            record["message"] = message
+            record["finished_at"] = _utc_now()
+            record["summary"] = summary
+
+    def _resolve_artifact_path(
+        self,
+        run_id: str,
+        name: str,
+        allowed_map: Dict[str, str],
+    ) -> Path:
+        key = allowed_map.get(name)
+        if key is None:
+            raise KeyError("unsupported file name")
+
+        with self._lock:
+            record = self._runs.get(run_id)
+            if record is None:
+                raise FileNotFoundError("run not found")
+            summary = record.get("summary")
+            if not isinstance(summary, dict):
+                raise FileNotFoundError("run summary is not ready")
+            artifacts = summary.get("artifacts")
+            if not isinstance(artifacts, dict):
+                raise FileNotFoundError("artifact map missing")
+            raw_path = artifacts.get(key)
+            run_dir_raw = artifacts.get("run_dir")
+
+        if not isinstance(raw_path, str) or not raw_path:
+            raise FileNotFoundError("artifact path missing")
+        path = Path(raw_path)
+        if not path.exists() or not path.is_file():
+            raise FileNotFoundError("artifact file missing")
+
+        if isinstance(run_dir_raw, str) and run_dir_raw:
+            run_dir = Path(run_dir_raw).resolve()
+            resolved = path.resolve()
+            try:
+                resolved.relative_to(run_dir)
+            except ValueError as exc:
+                raise PermissionError("artifact path escapes run directory") from exc
+        return path
+
+    @staticmethod
+    def _load_report(summary: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        artifacts = summary.get("artifacts")
+        if not isinstance(artifacts, dict):
+            return None
+        report_path = artifacts.get("report_json")
+        if not isinstance(report_path, str) or not report_path:
+            return None
+        path = Path(report_path)
+        if not path.exists() or not path.is_file():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
 
 
 def run_demo_server(config: DemoWebConfig) -> None:
-    """Run the minimal dashboard server until interrupted."""
+    """Run the dashboard server until interrupted."""
     config.validate()
-    static_dir = Path(__file__).resolve().parent / "static"
-    handler_cls = _build_handler(config, static_dir)
-    server = ThreadingHTTPServer((config.host, config.port), handler_cls)
+    server, _app = create_demo_http_server(config)
     try:
         server.serve_forever()
     finally:
         server.server_close()
 
 
-def _build_handler(config: DemoWebConfig, static_dir: Path):
+def create_demo_http_server(
+    config: DemoWebConfig,
+    *,
+    runner_factory: Optional[Callable[[], DemoRunner]] = None,
+) -> Tuple[ThreadingHTTPServer, DemoWebApp]:
+    """Create HTTP server and app manager; useful for tests."""
+    static_dir = Path(__file__).resolve().parent / "static"
+    app = DemoWebApp(config, runner_factory=runner_factory)
+    handler_cls = _build_handler(config, static_dir, app)
+    server = ThreadingHTTPServer((config.host, config.port), handler_cls)
+    return server, app
+
+
+def _build_handler(config: DemoWebConfig, static_dir: Path, app: DemoWebApp):
     class _Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
-            if self.path in ("/", "/index.html"):
+            parsed = urlparse(self.path)
+            path = parsed.path
+            if path in ("/", "/index.html"):
                 self._send_file(static_dir / "index.html", "text/html; charset=utf-8")
                 return
-            if self.path == "/app.js":
+            if path == "/app.js":
                 self._send_file(
                     static_dir / "app.js",
                     "application/javascript; charset=utf-8",
                 )
                 return
-            if self.path == "/styles.css":
+            if path == "/styles.css":
                 self._send_file(
                     static_dir / "styles.css",
                     "text/css; charset=utf-8",
                 )
                 return
-            if self.path == "/api/health":
-                payload = {
-                    "status": "ok",
-                    "mode": "skeleton",
-                    "config": config.as_dict(),
-                }
-                self._send_json(payload, status=HTTPStatus.OK)
+            if path == "/api/health":
+                self._send_json(app.health(), status=HTTPStatus.OK)
+                return
+
+            run_details = match_run_api_path(path)
+            if run_details:
+                run_id, endpoint_type, name = run_details
+                if endpoint_type == "run":
+                    payload = app.get_run_payload(run_id)
+                    if payload is None:
+                        self._send_json(
+                            {"error": "run not found", "run_id": run_id},
+                            status=HTTPStatus.NOT_FOUND,
+                        )
+                    else:
+                        self._send_json(payload, status=HTTPStatus.OK)
+                    return
+                if endpoint_type == "log":
+                    self._send_run_file(
+                        resolver=partial(app.resolve_log_path, run_id, name),
+                        content_type="text/plain; charset=utf-8",
+                    )
+                    return
+                if endpoint_type == "artifact":
+                    content_type = (
+                        "application/json; charset=utf-8"
+                        if name.endswith(".json")
+                        else "application/octet-stream"
+                    )
+                    self._send_run_file(
+                        resolver=partial(app.resolve_artifact_path, run_id, name),
+                        content_type=content_type,
+                    )
+                    return
+
+            self._send_json(
+                {"error": "not found", "path": path},
+                status=HTTPStatus.NOT_FOUND,
+            )
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path == "/api/runs":
+                payload = app.start_run()
+                self._send_json(payload, status=HTTPStatus.ACCEPTED)
                 return
             self._send_json(
-                {"error": "not found", "path": self.path},
+                {"error": "not found", "path": parsed.path},
                 status=HTTPStatus.NOT_FOUND,
             )
 
@@ -60,6 +285,22 @@ def _build_handler(config: DemoWebConfig, static_dir: Path):
         def _send_file(self, path: Path, content_type: str) -> None:
             if not path.exists() or not path.is_file():
                 self._send_json({"error": "file missing"}, status=HTTPStatus.NOT_FOUND)
+                return
+            data = path.read_bytes()
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _send_run_file(self, resolver: Callable[[], Path], content_type: str) -> None:
+            try:
+                path = resolver()
+            except FileNotFoundError as exc:
+                self._send_json({"error": str(exc)}, status=HTTPStatus.NOT_FOUND)
+                return
+            except (PermissionError, KeyError) as exc:
+                self._send_json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
                 return
             data = path.read_bytes()
             self.send_response(HTTPStatus.OK)
@@ -78,3 +319,29 @@ def _build_handler(config: DemoWebConfig, static_dir: Path):
 
     return _Handler
 
+
+def match_run_api_path(path: str) -> Optional[Tuple[str, str, str]]:
+    # /api/runs/{run_id}
+    # /api/runs/{run_id}/logs/{name}
+    # /api/runs/{run_id}/artifacts/{name}
+    parts = [part for part in path.split("/") if part]
+    if len(parts) == 3 and parts[0] == "api" and parts[1] == "runs":
+        return parts[2], "run", ""
+    if len(parts) == 5 and parts[0] == "api" and parts[1] == "runs":
+        endpoint = parts[3]
+        if endpoint == "logs":
+            return parts[2], "log", parts[4]
+        if endpoint == "artifacts":
+            return parts[2], "artifact", parts[4]
+    return None
+
+
+def _new_run_id() -> str:
+    now = datetime.now(timezone.utc)
+    return now.strftime("web-%Y%m%d-%H%M%S-%f")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )

--- a/libp2p_privacy_poc/demo_web/static/app.js
+++ b/libp2p_privacy_poc/demo_web/static/app.js
@@ -3,6 +3,7 @@ const bannerEl = document.getElementById("banner");
 const runJsonEl = document.getElementById("run-json");
 const statementCardsEl = document.getElementById("statement-cards");
 const trafficPanelEl = document.getElementById("traffic-panel");
+const proofSummaryEl = document.getElementById("proof-summary");
 const pinPanelEl = document.getElementById("pin-panel");
 const artifactLinksEl = document.getElementById("artifact-links");
 const logControlsEl = document.getElementById("log-controls");
@@ -16,11 +17,21 @@ function setBanner(status, message) {
   bannerEl.className = `card banner banner-${status}`;
 }
 
+function formatMs(value) {
+  if (!Number.isFinite(value)) return "n/a";
+  return `${Number(value).toFixed(3)} ms`;
+}
+
+function shortHash(hashText) {
+  if (typeof hashText !== "string" || hashText.length < 12) return "n/a";
+  return `${hashText.slice(0, 12)}...`;
+}
+
 function statementMapFrom(payload) {
   const empty = {
-    membership_v2: { verified: false, mode: "n/a", timing: "n/a" },
-    continuity_v2: { verified: false, mode: "n/a", timing: "n/a" },
-    unlinkability_v2: { verified: false, mode: "n/a", timing: "n/a" },
+    membership_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a" },
+    continuity_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a" },
+    unlinkability_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a" },
   };
 
   const report = payload.report || {};
@@ -30,11 +41,13 @@ function statementMapFrom(payload) {
   for (const row of rows) {
     if (!row || !row.statement || !(row.statement in empty)) continue;
     const meta = row.meta || {};
-    const timingMs = meta.round_trip_ms ?? meta.verify_ms ?? meta.elapsed_ms;
+    const verifyMs = row.verify_ms ?? meta.verify_ms ?? meta.elapsed_ms;
+    const exchangeMs = row.exchange_ms ?? meta.exchange_ms ?? meta.round_trip_ms;
     empty[row.statement] = {
       verified: row.verified === true,
       mode: row.prove_mode || meta.prove_mode || row.mode || "n/a",
-      timing: Number.isFinite(timingMs) ? `${timingMs} ms` : "n/a",
+      verifyTime: formatMs(verifyMs),
+      exchangeTime: formatMs(exchangeMs),
     };
   }
 
@@ -53,7 +66,8 @@ function renderStatements(payload) {
         ${row.verified ? "verified" : "not verified"}
       </div>
       <div class="statement-meta">prove_mode: ${row.mode}</div>
-      <div class="statement-meta">timing: ${row.timing}</div>
+      <div class="statement-meta">verify: ${row.verifyTime}</div>
+      <div class="statement-meta">exchange: ${row.exchangeTime}</div>
     `;
     statementCardsEl.appendChild(div);
   }
@@ -69,6 +83,55 @@ function renderTraffic(payload) {
     <div><strong>Requested traffic nodes:</strong> ${requested}</div>
     <div><strong>Observed unique peers:</strong> ${observed}</div>
     <div><strong>Total connections:</strong> ${connections}</div>
+  `;
+}
+
+function renderProofSummary(payload) {
+  const report = payload.report || {};
+  const summary = report.proof_exchange_summary || {};
+  const statements = Array.isArray(summary.statements) ? summary.statements : [];
+  if (!statements.length) {
+    proofSummaryEl.innerHTML = "<div>No proof exchange summary available.</div>";
+    return;
+  }
+
+  const rows = statements
+    .map((row) => {
+      const verified = row.verified === true ? "✓" : "✗";
+      const assetHash = shortHash(((row.asset_source || {}).sha256));
+      return `
+        <tr>
+          <td>${row.statement || "n/a"}</td>
+          <td>${verified}</td>
+          <td>v${row.schema_v ?? "n/a"}</td>
+          <td>${row.depth ?? "n/a"}</td>
+          <td>${row.prove_mode || "n/a"}</td>
+          <td>${formatMs(row.verify_ms)}</td>
+          <td>${formatMs(row.exchange_ms)}</td>
+          <td>${assetHash}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  proofSummaryEl.innerHTML = `
+    <div><strong>Protocol:</strong> ${summary.protocol_id || "n/a"}</div>
+    <div><strong>Peer:</strong> ${summary.peer_multiaddr || "n/a"}</div>
+    <table class="summary-table">
+      <thead>
+        <tr>
+          <th>Statement</th>
+          <th>OK</th>
+          <th>Schema</th>
+          <th>Depth</th>
+          <th>Mode</th>
+          <th>Verify</th>
+          <th>Exchange</th>
+          <th>Asset Hash</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
   `;
 }
 
@@ -113,10 +176,14 @@ function renderArtifactLinks(payload) {
   }
 }
 
-function renderLogControls() {
+function renderLogControls(payload) {
   logControlsEl.innerHTML = "";
   if (!currentRunId) {
     logControlsEl.textContent = "No run yet.";
+    return;
+  }
+  if (payload.status === "running" || !payload.summary) {
+    logControlsEl.textContent = "Logs become available after run completion.";
     return;
   }
 
@@ -128,7 +195,14 @@ function renderLogControls() {
       try {
         const res = await fetch(`/api/runs/${currentRunId}/logs/${name}`);
         if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`);
+          let detail = "";
+          try {
+            const payload = await res.json();
+            detail = payload.error ? `: ${payload.error}` : "";
+          } catch (_err) {
+            detail = "";
+          }
+          throw new Error(`HTTP ${res.status}${detail}`);
         }
         logViewerEl.textContent = await res.text();
       } catch (err) {
@@ -143,9 +217,10 @@ function renderRun(payload) {
   runJsonEl.textContent = JSON.stringify(payload, null, 2);
   renderStatements(payload);
   renderTraffic(payload);
+  renderProofSummary(payload);
   renderPin(payload);
   renderArtifactLinks(payload);
-  renderLogControls();
+  renderLogControls(payload);
 
   if (payload.status === "running") {
     setBanner("running", "Run in progress...");

--- a/libp2p_privacy_poc/demo_web/static/app.js
+++ b/libp2p_privacy_poc/demo_web/static/app.js
@@ -110,24 +110,43 @@ function renderOverviewStats(payload) {
 }
 
 function renderRiskPanel(payload) {
+  const report = payload.report || {};
+  const privacyReport = report.privacy_report || {};
+  const scoreRaw = privacyReport.overall_risk_score;
+  const levelRaw = privacyReport.risk_level;
+  const score = Number.isFinite(Number(scoreRaw)) ? Number(scoreRaw) : null;
+
   const map = statementMapFrom(payload);
   const verified = Object.values(map).filter((r) => r.verified).length;
 
-  let riskLevel, riskColor, riskPct;
-  if (verified === 3) {
-    riskLevel = "Low Risk";
+  let riskLevel;
+  if (typeof levelRaw === "string" && levelRaw.trim()) {
+    riskLevel = levelRaw.toUpperCase();
+  } else if (score !== null) {
+    if (score >= 0.75) riskLevel = "CRITICAL";
+    else if (score >= 0.5) riskLevel = "HIGH";
+    else if (score >= 0.25) riskLevel = "MEDIUM";
+    else riskLevel = "LOW";
+  } else {
+    // Fallback only when report score is unavailable.
+    if (verified === 3) riskLevel = "LOW";
+    else if (verified === 2) riskLevel = "MEDIUM";
+    else if (verified === 1) riskLevel = "HIGH";
+    else riskLevel = "CRITICAL";
+  }
+
+  let riskColor = "var(--warn)";
+  let riskPct = 50;
+  if (riskLevel === "LOW") {
     riskColor = "var(--ok)";
     riskPct = 15;
-  } else if (verified === 2) {
-    riskLevel = "Medium Risk";
+  } else if (riskLevel === "MEDIUM") {
     riskColor = "var(--warn)";
     riskPct = 55;
-  } else if (verified === 1) {
-    riskLevel = "Elevated Risk";
+  } else if (riskLevel === "HIGH") {
     riskColor = "var(--warn)";
     riskPct = 75;
-  } else {
-    riskLevel = "High Risk";
+  } else if (riskLevel === "CRITICAL") {
     riskColor = "var(--bad)";
     riskPct = 95;
   }
@@ -148,7 +167,9 @@ function renderRiskPanel(payload) {
       `</div>` +
       `<div>` +
         `<div class="risk-label" style="color:${riskColor};font-size:1.15rem">${riskLevel}</div>` +
-        `<div style="color:var(--text-muted);font-size:0.78rem;margin-top:2px">${verified} of 3 proofs verified</div>` +
+        `<div style="color:var(--text-muted);font-size:0.78rem;margin-top:2px">` +
+          `Risk from network analysis${score !== null ? ` (${score.toFixed(2)}/1.00)` : ""}` +
+        `</div>` +
       `</div>` +
     `</div>` +
     `<div class="mini-bar-group" style="margin-top:16px">` +

--- a/libp2p_privacy_poc/demo_web/static/app.js
+++ b/libp2p_privacy_poc/demo_web/static/app.js
@@ -1,13 +1,208 @@
-async function loadHealth() {
-  const el = document.getElementById("health");
-  try {
-    const res = await fetch("/api/health");
-    const data = await res.json();
-    el.textContent = JSON.stringify(data, null, 2);
-  } catch (err) {
-    el.textContent = `Failed to load health: ${err}`;
+const runBtn = document.getElementById("run-btn");
+const bannerEl = document.getElementById("banner");
+const runJsonEl = document.getElementById("run-json");
+const statementCardsEl = document.getElementById("statement-cards");
+const trafficPanelEl = document.getElementById("traffic-panel");
+const pinPanelEl = document.getElementById("pin-panel");
+const artifactLinksEl = document.getElementById("artifact-links");
+const logControlsEl = document.getElementById("log-controls");
+const logViewerEl = document.getElementById("log-viewer");
+
+let currentRunId = null;
+let pollTimer = null;
+
+function setBanner(status, message) {
+  bannerEl.textContent = message || status;
+  bannerEl.className = `card banner banner-${status}`;
+}
+
+function statementMapFrom(payload) {
+  const empty = {
+    membership_v2: { verified: false, mode: "n/a", timing: "n/a" },
+    continuity_v2: { verified: false, mode: "n/a", timing: "n/a" },
+    unlinkability_v2: { verified: false, mode: "n/a", timing: "n/a" },
+  };
+
+  const report = payload.report || {};
+  const rows = Array.isArray(report.snark_phase2b_proofs)
+    ? report.snark_phase2b_proofs
+    : [];
+  for (const row of rows) {
+    if (!row || !row.statement || !(row.statement in empty)) continue;
+    const meta = row.meta || {};
+    const timingMs = meta.round_trip_ms ?? meta.verify_ms ?? meta.elapsed_ms;
+    empty[row.statement] = {
+      verified: row.verified === true,
+      mode: row.prove_mode || meta.prove_mode || row.mode || "n/a",
+      timing: Number.isFinite(timingMs) ? `${timingMs} ms` : "n/a",
+    };
+  }
+
+  return empty;
+}
+
+function renderStatements(payload) {
+  const map = statementMapFrom(payload);
+  statementCardsEl.innerHTML = "";
+  for (const [name, row] of Object.entries(map)) {
+    const div = document.createElement("div");
+    div.className = "statement";
+    div.innerHTML = `
+      <div class="statement-title">${name}</div>
+      <div class="statement-status ${row.verified ? "ok" : "bad"}">
+        ${row.verified ? "verified" : "not verified"}
+      </div>
+      <div class="statement-meta">prove_mode: ${row.mode}</div>
+      <div class="statement-meta">timing: ${row.timing}</div>
+    `;
+    statementCardsEl.appendChild(div);
   }
 }
 
-loadHealth();
+function renderTraffic(payload) {
+  const report = payload.report || {};
+  const stats = (report.privacy_report || {}).statistics || {};
+  const requested = (payload.config || {}).traffic_nodes ?? "n/a";
+  const observed = stats.unique_peers ?? "n/a";
+  const connections = stats.total_connections ?? "n/a";
+  trafficPanelEl.innerHTML = `
+    <div><strong>Requested traffic nodes:</strong> ${requested}</div>
+    <div><strong>Observed unique peers:</strong> ${observed}</div>
+    <div><strong>Total connections:</strong> ${connections}</div>
+  `;
+}
 
+function renderPin(payload) {
+  const pin = (payload.summary || {}).pin || {};
+  const pinResults = Array.isArray(pin.pin_results) ? pin.pin_results : [];
+  const cids = pinResults.map((x) => x.cid).filter(Boolean);
+
+  pinPanelEl.innerHTML = `
+    <div><strong>Requested mode:</strong> ${pin.mode_requested || "n/a"}</div>
+    <div><strong>Backend used:</strong> ${pin.backend_used || "n/a"}</div>
+    <div><strong>Fallback to mock:</strong> ${pin.fell_back_to_mock === true ? "yes" : "no"}</div>
+    <div><strong>Pin status:</strong> ${pin.error ? `error (${pin.error})` : "ok"}</div>
+    <div><strong>CIDs:</strong> ${cids.length ? cids.join(", ") : "n/a"}</div>
+  `;
+}
+
+function renderArtifactLinks(payload) {
+  artifactLinksEl.innerHTML = "";
+  if (!currentRunId) {
+    artifactLinksEl.textContent = "No run yet.";
+    return;
+  }
+
+  const links = [
+    { label: "summary.json", href: `/api/runs/${currentRunId}/artifacts/summary.json` },
+    { label: "report.json", href: `/api/runs/${currentRunId}/artifacts/report.json` },
+    { label: "zk_serve.log", href: `/api/runs/${currentRunId}/logs/server` },
+    { label: "analyze.log", href: `/api/runs/${currentRunId}/logs/analyze` },
+    { label: "zk_dial.log", href: `/api/runs/${currentRunId}/logs/dial` },
+    { label: "pin.log", href: `/api/runs/${currentRunId}/logs/pin` },
+    { label: "fetch.log", href: `/api/runs/${currentRunId}/logs/fetch` },
+  ];
+
+  for (const item of links) {
+    const a = document.createElement("a");
+    a.href = item.href;
+    a.textContent = item.label;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    artifactLinksEl.appendChild(a);
+  }
+}
+
+function renderLogControls() {
+  logControlsEl.innerHTML = "";
+  if (!currentRunId) {
+    logControlsEl.textContent = "No run yet.";
+    return;
+  }
+
+  const names = ["server", "analyze", "dial", "pin", "fetch"];
+  for (const name of names) {
+    const btn = document.createElement("button");
+    btn.textContent = `View ${name}.log`;
+    btn.addEventListener("click", async () => {
+      try {
+        const res = await fetch(`/api/runs/${currentRunId}/logs/${name}`);
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        logViewerEl.textContent = await res.text();
+      } catch (err) {
+        logViewerEl.textContent = `Failed to load log: ${err}`;
+      }
+    });
+    logControlsEl.appendChild(btn);
+  }
+}
+
+function renderRun(payload) {
+  runJsonEl.textContent = JSON.stringify(payload, null, 2);
+  renderStatements(payload);
+  renderTraffic(payload);
+  renderPin(payload);
+  renderArtifactLinks(payload);
+  renderLogControls();
+
+  if (payload.status === "running") {
+    setBanner("running", "Run in progress...");
+    runBtn.disabled = true;
+    return;
+  }
+  if (payload.status === "success") {
+    setBanner("success", payload.message || "Run succeeded.");
+  } else if (payload.status === "fallback") {
+    setBanner("fallback", payload.message || "Fallback detected.");
+  } else {
+    setBanner("failed", payload.message || "Run failed.");
+  }
+  runBtn.disabled = false;
+}
+
+async function pollRun(runId) {
+  try {
+    const res = await fetch(`/api/runs/${runId}`);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const payload = await res.json();
+    renderRun(payload);
+    if (payload.status !== "running" && pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  } catch (err) {
+    setBanner("failed", `Polling failed: ${err}`);
+    runBtn.disabled = false;
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+}
+
+async function startRun() {
+  runBtn.disabled = true;
+  setBanner("running", "Starting run...");
+  logViewerEl.textContent = "No log selected.";
+  try {
+    const res = await fetch("/api/runs", { method: "POST" });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const payload = await res.json();
+    currentRunId = payload.run_id;
+    renderRun(payload);
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = setInterval(() => pollRun(currentRunId), 1000);
+  } catch (err) {
+    setBanner("failed", `Failed to start run: ${err}`);
+    runBtn.disabled = false;
+  }
+}
+
+runBtn.addEventListener("click", startRun);
+setBanner("ready", 'Ready. Click "Run Full Demo".');

--- a/libp2p_privacy_poc/demo_web/static/app.js
+++ b/libp2p_privacy_poc/demo_web/static/app.js
@@ -1,0 +1,13 @@
+async function loadHealth() {
+  const el = document.getElementById("health");
+  try {
+    const res = await fetch("/api/health");
+    const data = await res.json();
+    el.textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    el.textContent = `Failed to load health: ${err}`;
+  }
+}
+
+loadHealth();
+

--- a/libp2p_privacy_poc/demo_web/static/app.js
+++ b/libp2p_privacy_poc/demo_web/static/app.js
@@ -8,9 +8,17 @@ const pinPanelEl = document.getElementById("pin-panel");
 const artifactLinksEl = document.getElementById("artifact-links");
 const logControlsEl = document.getElementById("log-controls");
 const logViewerEl = document.getElementById("log-viewer");
+const timingChartEl = document.getElementById("timing-chart");
+const riskPanelEl = document.getElementById("risk-panel");
+const ovVerifiedEl = document.getElementById("ov-verified");
+const ovPeersEl = document.getElementById("ov-peers");
+const ovConnectionsEl = document.getElementById("ov-connections");
 
 let currentRunId = null;
 let pollTimer = null;
+let activeLogBtn = null;
+
+/* ─── Helpers ─── */
 
 function setBanner(status, message) {
   bannerEl.textContent = message || status;
@@ -22,16 +30,23 @@ function formatMs(value) {
   return `${Number(value).toFixed(3)} ms`;
 }
 
+function rawMs(value) {
+  if (!Number.isFinite(value)) return null;
+  return Number(value);
+}
+
 function shortHash(hashText) {
   if (typeof hashText !== "string" || hashText.length < 12) return "n/a";
-  return `${hashText.slice(0, 12)}...`;
+  return `${hashText.slice(0, 12)}\u2026`;
 }
+
+/* ─── Statement data extraction ─── */
 
 function statementMapFrom(payload) {
   const empty = {
-    membership_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a" },
-    continuity_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a" },
-    unlinkability_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a" },
+    membership_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a", verifyRaw: null, exchangeRaw: null },
+    continuity_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a", verifyRaw: null, exchangeRaw: null },
+    unlinkability_v2: { verified: false, mode: "n/a", verifyTime: "n/a", exchangeTime: "n/a", verifyRaw: null, exchangeRaw: null },
   };
 
   const report = payload.report || {};
@@ -48,29 +63,149 @@ function statementMapFrom(payload) {
       mode: row.prove_mode || meta.prove_mode || row.mode || "n/a",
       verifyTime: formatMs(verifyMs),
       exchangeTime: formatMs(exchangeMs),
+      verifyRaw: rawMs(verifyMs),
+      exchangeRaw: rawMs(exchangeMs),
     };
   }
 
   return empty;
 }
 
+/* ─── Renderers ─── */
+
 function renderStatements(payload) {
   const map = statementMapFrom(payload);
   statementCardsEl.innerHTML = "";
   for (const [name, row] of Object.entries(map)) {
     const div = document.createElement("div");
-    div.className = "statement";
-    div.innerHTML = `
-      <div class="statement-title">${name}</div>
-      <div class="statement-status ${row.verified ? "ok" : "bad"}">
-        ${row.verified ? "verified" : "not verified"}
-      </div>
-      <div class="statement-meta">prove_mode: ${row.mode}</div>
-      <div class="statement-meta">verify: ${row.verifyTime}</div>
-      <div class="statement-meta">exchange: ${row.exchangeTime}</div>
-    `;
+    div.className = `statement ${row.verified ? "verified" : "not-verified"}`;
+    div.innerHTML =
+      `<div class="statement-header">` +
+        `<div class="statement-title">${name}</div>` +
+        `<span class="statement-badge ${row.verified ? "badge-ok" : "badge-bad"}">` +
+          `${row.verified ? "\u2713 Verified" : "\u2717 Failed"}` +
+        `</span>` +
+      `</div>` +
+      `<div class="statement-meta-grid">` +
+        `<div class="meta-item"><span class="meta-key">Mode</span><span class="meta-val">${row.mode}</span></div>` +
+        `<div class="meta-item"><span class="meta-key">Verify</span><span class="meta-val">${row.verifyTime}</span></div>` +
+        `<div class="meta-item"><span class="meta-key">Exchange</span><span class="meta-val">${row.exchangeTime}</span></div>` +
+        `<div class="meta-item"><span class="meta-key">Status</span><span class="meta-val">${row.verified ? "Pass" : "Fail"}</span></div>` +
+      `</div>`;
     statementCardsEl.appendChild(div);
   }
+}
+
+function renderOverviewStats(payload) {
+  const map = statementMapFrom(payload);
+  const verified = Object.values(map).filter((r) => r.verified).length;
+
+  ovVerifiedEl.textContent = `${verified}/3`;
+  ovVerifiedEl.className = `stat-value ${verified === 3 ? "stat-ok" : verified > 0 ? "stat-warn" : "stat-bad"}`;
+
+  const report = payload.report || {};
+  const stats = (report.privacy_report || {}).statistics || {};
+  ovPeersEl.textContent = stats.unique_peers ?? "—";
+  ovConnectionsEl.textContent = stats.total_connections ?? "—";
+}
+
+function renderRiskPanel(payload) {
+  const map = statementMapFrom(payload);
+  const verified = Object.values(map).filter((r) => r.verified).length;
+
+  let riskLevel, riskColor, riskPct;
+  if (verified === 3) {
+    riskLevel = "Low Risk";
+    riskColor = "var(--ok)";
+    riskPct = 15;
+  } else if (verified === 2) {
+    riskLevel = "Medium Risk";
+    riskColor = "var(--warn)";
+    riskPct = 55;
+  } else if (verified === 1) {
+    riskLevel = "Elevated Risk";
+    riskColor = "var(--warn)";
+    riskPct = 75;
+  } else {
+    riskLevel = "High Risk";
+    riskColor = "var(--bad)";
+    riskPct = 95;
+  }
+
+  // SVG arc gauge for risk
+  const circumference = Math.PI * 32;
+  const halfCirc = circumference;
+  const dashOffset = halfCirc - (halfCirc * riskPct) / 100;
+
+  riskPanelEl.innerHTML =
+    `<div class="risk-meter">` +
+      `<div class="risk-arc">` +
+        `<svg viewBox="0 0 80 80">` +
+          `<circle class="risk-arc-bg" cx="40" cy="40" r="32" stroke-dasharray="${halfCirc}" stroke-dashoffset="0" />` +
+          `<circle class="risk-arc-fill" cx="40" cy="40" r="32" stroke="${riskColor}" ` +
+            `stroke-dasharray="${halfCirc}" stroke-dashoffset="${dashOffset}" />` +
+        `</svg>` +
+      `</div>` +
+      `<div>` +
+        `<div class="risk-label" style="color:${riskColor};font-size:1.15rem">${riskLevel}</div>` +
+        `<div style="color:var(--text-muted);font-size:0.78rem;margin-top:2px">${verified} of 3 proofs verified</div>` +
+      `</div>` +
+    `</div>` +
+    `<div class="mini-bar-group" style="margin-top:16px">` +
+      Object.entries(map).map(([name, row]) => {
+        const color = row.verified ? "var(--ok)" : "var(--bad)";
+        return `<div class="mini-bar-row">` +
+          `<span class="mini-bar-label">${name.replace("_v2", "")}</span>` +
+          `<div class="mini-bar-track"><div class="mini-bar-fill" style="width:${row.verified ? "100" : "0"}%;background:${color}"></div></div>` +
+          `<span class="mini-bar-value" style="color:${color}">${row.verified ? "Pass" : "Fail"}</span>` +
+        `</div>`;
+      }).join("") +
+    `</div>`;
+}
+
+function renderTimingChart(payload) {
+  const map = statementMapFrom(payload);
+  const allTimes = [];
+  for (const row of Object.values(map)) {
+    if (row.verifyRaw !== null) allTimes.push(row.verifyRaw);
+    if (row.exchangeRaw !== null) allTimes.push(row.exchangeRaw);
+  }
+
+  if (allTimes.length === 0) {
+    timingChartEl.innerHTML = `<div class="empty-state">No timing data available yet.</div>`;
+    return;
+  }
+
+  const maxTime = Math.max(...allTimes, 1);
+
+  let html = "";
+  for (const [name, row] of Object.entries(map)) {
+    const vPct = row.verifyRaw !== null ? Math.max((row.verifyRaw / maxTime) * 100, 2) : 0;
+    const ePct = row.exchangeRaw !== null ? Math.max((row.exchangeRaw / maxTime) * 100, 2) : 0;
+
+    html +=
+      `<div class="timing-row">` +
+        `<div class="timing-label">${name}</div>` +
+        `<div class="timing-bars">` +
+          `<div class="timing-bar-wrapper">` +
+            `<div class="timing-bar-track"><div class="timing-bar verify-bar" style="width:${vPct}%"></div></div>` +
+            `<span class="timing-bar-ms">${row.verifyTime}</span>` +
+          `</div>` +
+          `<div class="timing-bar-wrapper">` +
+            `<div class="timing-bar-track"><div class="timing-bar exchange-bar" style="width:${ePct}%"></div></div>` +
+            `<span class="timing-bar-ms">${row.exchangeTime}</span>` +
+          `</div>` +
+        `</div>` +
+      `</div>`;
+  }
+
+  html +=
+    `<div class="timing-legend">` +
+      `<div class="timing-legend-item"><span class="timing-legend-swatch swatch-verify"></span>Verify</div>` +
+      `<div class="timing-legend-item"><span class="timing-legend-swatch swatch-exchange"></span>Exchange</div>` +
+    `</div>`;
+
+  timingChartEl.innerHTML = html;
 }
 
 function renderTraffic(payload) {
@@ -79,11 +214,30 @@ function renderTraffic(payload) {
   const requested = (payload.config || {}).traffic_nodes ?? "n/a";
   const observed = stats.unique_peers ?? "n/a";
   const connections = stats.total_connections ?? "n/a";
-  trafficPanelEl.innerHTML = `
-    <div><strong>Requested traffic nodes:</strong> ${requested}</div>
-    <div><strong>Observed unique peers:</strong> ${observed}</div>
-    <div><strong>Total connections:</strong> ${connections}</div>
-  `;
+
+  const maxVal = Math.max(
+    Number(requested) || 0,
+    Number(observed) || 0,
+    Number(connections) || 0,
+    1
+  );
+
+  trafficPanelEl.innerHTML =
+    `<div class="mini-bar-group">` +
+      _trafficBarRow("Requested nodes", requested, maxVal, "var(--accent)") +
+      _trafficBarRow("Unique peers", observed, maxVal, "var(--ok)") +
+      _trafficBarRow("Total connections", connections, maxVal, "#0fbcf9") +
+    `</div>`;
+}
+
+function _trafficBarRow(label, value, max, color) {
+  const numVal = Number(value);
+  const pct = Number.isFinite(numVal) && max > 0 ? Math.max((numVal / max) * 100, 2) : 0;
+  return `<div class="mini-bar-row">` +
+    `<span class="mini-bar-label">${label}</span>` +
+    `<div class="mini-bar-track"><div class="mini-bar-fill" style="width:${pct}%;background:${color}"></div></div>` +
+    `<span class="mini-bar-value">${value}</span>` +
+  `</div>`;
 }
 
 function renderProofSummary(payload) {
@@ -91,48 +245,37 @@ function renderProofSummary(payload) {
   const summary = report.proof_exchange_summary || {};
   const statements = Array.isArray(summary.statements) ? summary.statements : [];
   if (!statements.length) {
-    proofSummaryEl.innerHTML = "<div>No proof exchange summary available.</div>";
+    proofSummaryEl.innerHTML = `<div class="empty-state">No proof exchange summary available.</div>`;
     return;
   }
 
   const rows = statements
     .map((row) => {
-      const verified = row.verified === true ? "✓" : "✗";
+      const verified = row.verified === true;
       const assetHash = shortHash(((row.asset_source || {}).sha256));
-      return `
-        <tr>
-          <td>${row.statement || "n/a"}</td>
-          <td>${verified}</td>
-          <td>v${row.schema_v ?? "n/a"}</td>
-          <td>${row.depth ?? "n/a"}</td>
-          <td>${row.prove_mode || "n/a"}</td>
-          <td>${formatMs(row.verify_ms)}</td>
-          <td>${formatMs(row.exchange_ms)}</td>
-          <td>${assetHash}</td>
-        </tr>
-      `;
+      return `<tr>` +
+        `<td>${row.statement || "n/a"}</td>` +
+        `<td class="${verified ? "cell-ok" : "cell-bad"}">${verified ? "\u2713" : "\u2717"}</td>` +
+        `<td>v${row.schema_v ?? "n/a"}</td>` +
+        `<td>${row.depth ?? "n/a"}</td>` +
+        `<td>${row.prove_mode || "n/a"}</td>` +
+        `<td>${formatMs(row.verify_ms)}</td>` +
+        `<td>${formatMs(row.exchange_ms)}</td>` +
+        `<td>${assetHash}</td>` +
+      `</tr>`;
     })
     .join("");
 
-  proofSummaryEl.innerHTML = `
-    <div><strong>Protocol:</strong> ${summary.protocol_id || "n/a"}</div>
-    <div><strong>Peer:</strong> ${summary.peer_multiaddr || "n/a"}</div>
-    <table class="summary-table">
-      <thead>
-        <tr>
-          <th>Statement</th>
-          <th>OK</th>
-          <th>Schema</th>
-          <th>Depth</th>
-          <th>Mode</th>
-          <th>Verify</th>
-          <th>Exchange</th>
-          <th>Asset Hash</th>
-        </tr>
-      </thead>
-      <tbody>${rows}</tbody>
-    </table>
-  `;
+  proofSummaryEl.innerHTML =
+    `<div class="kv-row"><span class="kv-key">Protocol</span><span class="protocol-tag">${summary.protocol_id || "n/a"}</span></div>` +
+    `<div class="kv-row"><span class="kv-key">Peer</span><span class="peer-addr">${summary.peer_multiaddr || "n/a"}</span></div>` +
+    `<table class="summary-table">` +
+      `<thead><tr>` +
+        `<th>Statement</th><th>OK</th><th>Schema</th><th>Depth</th>` +
+        `<th>Mode</th><th>Verify</th><th>Exchange</th><th>Asset Hash</th>` +
+      `</tr></thead>` +
+      `<tbody>${rows}</tbody>` +
+    `</table>`;
 }
 
 function renderPin(payload) {
@@ -140,19 +283,18 @@ function renderPin(payload) {
   const pinResults = Array.isArray(pin.pin_results) ? pin.pin_results : [];
   const cids = pinResults.map((x) => x.cid).filter(Boolean);
 
-  pinPanelEl.innerHTML = `
-    <div><strong>Requested mode:</strong> ${pin.mode_requested || "n/a"}</div>
-    <div><strong>Backend used:</strong> ${pin.backend_used || "n/a"}</div>
-    <div><strong>Fallback to mock:</strong> ${pin.fell_back_to_mock === true ? "yes" : "no"}</div>
-    <div><strong>Pin status:</strong> ${pin.error ? `error (${pin.error})` : "ok"}</div>
-    <div><strong>CIDs:</strong> ${cids.length ? cids.join(", ") : "n/a"}</div>
-  `;
+  pinPanelEl.innerHTML =
+    `<div class="kv-row"><span class="kv-key">Mode requested</span><span class="kv-val">${pin.mode_requested || "n/a"}</span></div>` +
+    `<div class="kv-row"><span class="kv-key">Backend used</span><span class="kv-val">${pin.backend_used || "n/a"}</span></div>` +
+    `<div class="kv-row"><span class="kv-key">Fallback to mock</span><span class="kv-val">${pin.fell_back_to_mock === true ? "yes" : "no"}</span></div>` +
+    `<div class="kv-row"><span class="kv-key">Status</span><span class="kv-val">${pin.error ? "error (" + pin.error + ")" : "ok"}</span></div>` +
+    `<div class="kv-row"><span class="kv-key">CIDs</span><span class="kv-val" style="font-size:0.78rem;word-break:break-all">${cids.length ? cids.join(", ") : "n/a"}</span></div>`;
 }
 
 function renderArtifactLinks(payload) {
   artifactLinksEl.innerHTML = "";
   if (!currentRunId) {
-    artifactLinksEl.textContent = "No run yet.";
+    artifactLinksEl.innerHTML = `<div class="empty-state">No run yet.</div>`;
     return;
   }
 
@@ -178,6 +320,7 @@ function renderArtifactLinks(payload) {
 
 function renderLogControls(payload) {
   logControlsEl.innerHTML = "";
+  activeLogBtn = null;
   if (!currentRunId) {
     logControlsEl.textContent = "No run yet.";
     return;
@@ -190,8 +333,11 @@ function renderLogControls(payload) {
   const names = ["server", "analyze", "dial", "pin", "fetch"];
   for (const name of names) {
     const btn = document.createElement("button");
-    btn.textContent = `View ${name}.log`;
+    btn.textContent = `${name}.log`;
     btn.addEventListener("click", async () => {
+      if (activeLogBtn) activeLogBtn.classList.remove("active");
+      btn.classList.add("active");
+      activeLogBtn = btn;
       try {
         const res = await fetch(`/api/runs/${currentRunId}/logs/${name}`);
         if (!res.ok) {
@@ -213,9 +359,14 @@ function renderLogControls(payload) {
   }
 }
 
+/* ─── Main render ─── */
+
 function renderRun(payload) {
   runJsonEl.textContent = JSON.stringify(payload, null, 2);
   renderStatements(payload);
+  renderOverviewStats(payload);
+  renderRiskPanel(payload);
+  renderTimingChart(payload);
   renderTraffic(payload);
   renderProofSummary(payload);
   renderPin(payload);
@@ -223,7 +374,7 @@ function renderRun(payload) {
   renderLogControls(payload);
 
   if (payload.status === "running") {
-    setBanner("running", "Run in progress...");
+    setBanner("running", "Run in progress\u2026");
     runBtn.disabled = true;
     return;
   }
@@ -236,6 +387,8 @@ function renderRun(payload) {
   }
   runBtn.disabled = false;
 }
+
+/* ─── Polling ─── */
 
 async function pollRun(runId) {
   try {
@@ -261,7 +414,7 @@ async function pollRun(runId) {
 
 async function startRun() {
   runBtn.disabled = true;
-  setBanner("running", "Starting run...");
+  setBanner("running", "Starting run\u2026");
   logViewerEl.textContent = "No log selected.";
   try {
     const res = await fetch("/api/runs", { method: "POST" });
@@ -279,5 +432,18 @@ async function startRun() {
   }
 }
 
+/* ─── Collapsible metadata toggle ─── */
+
+const metadataToggle = document.getElementById("metadata-toggle");
+const metadataBody = document.getElementById("metadata-body");
+if (metadataToggle && metadataBody) {
+  metadataToggle.addEventListener("click", () => {
+    metadataToggle.classList.toggle("open");
+    metadataBody.classList.toggle("open");
+  });
+}
+
+/* ─── Init ─── */
+
 runBtn.addEventListener("click", startRun);
-setBanner("ready", 'Ready. Click "Run Full Demo".');
+setBanner("ready", 'Ready. Click "Run End-to-End Validation".');

--- a/libp2p_privacy_poc/demo_web/static/index.html
+++ b/libp2p_privacy_poc/demo_web/static/index.html
@@ -8,14 +8,49 @@
   </head>
   <body>
     <main class="container">
-      <h1>Privacy Protocol Toolkit Demo Dashboard</h1>
-      <p class="subtitle">
-        Step 1 skeleton is active. Run orchestration, API, and live cards are added in later steps.
-      </p>
-      <button id="run-btn" disabled>Run Full Demo (coming next step)</button>
-      <pre id="health"></pre>
+      <header class="topbar">
+        <h1>Privacy Protocol Toolkit Dashboard</h1>
+        <button id="run-btn">Run Full Demo</button>
+      </header>
+
+      <section class="card banner" id="banner">
+        Ready. Click "Run Full Demo".
+      </section>
+
+      <section class="grid two-col">
+        <div class="card">
+          <h2>Statement Verification</h2>
+          <div class="statements" id="statement-cards"></div>
+        </div>
+        <div class="card">
+          <h2>Traffic</h2>
+          <div id="traffic-panel" class="kv"></div>
+        </div>
+      </section>
+
+      <section class="grid two-col">
+        <div class="card">
+          <h2>Pin Result</h2>
+          <div id="pin-panel" class="kv"></div>
+        </div>
+        <div class="card">
+          <h2>Artifacts</h2>
+          <div id="artifact-links" class="links"></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Logs</h2>
+        <div class="log-controls" id="log-controls"></div>
+        <pre id="log-viewer">No log selected.</pre>
+      </section>
+
+      <section class="card">
+        <h2>Run Metadata</h2>
+        <pre id="run-json">No run yet.</pre>
+      </section>
     </main>
+
     <script src="/app.js"></script>
   </body>
 </html>
-

--- a/libp2p_privacy_poc/demo_web/static/index.html
+++ b/libp2p_privacy_poc/demo_web/static/index.html
@@ -8,52 +8,106 @@
   </head>
   <body>
     <main class="container">
+
       <header class="topbar">
-        <h1>Privacy Protocol Toolkit Dashboard</h1>
-        <button id="run-btn">Run Full Demo</button>
+        <div class="topbar-brand">
+          <div class="topbar-logo">P</div>
+          <h1>Privacy Protocol <span>Dashboard</span></h1>
+        </div>
+        <button class="btn-primary" id="run-btn">&#9654; Run E2E Validation </button>
       </header>
 
-      <section class="card banner" id="banner">
+      <section class="card banner banner-ready" id="banner">
         Ready. Click "Run Full Demo".
       </section>
 
-      <section class="grid two-col">
-        <div class="card">
-          <h2>Statement Verification</h2>
-          <div class="statements" id="statement-cards"></div>
+      <!-- Overview Stats Row -->
+      <section class="grid overview-row section-gap" id="overview-row">
+        <div class="card stat-box">
+          <div class="stat-value stat-accent" id="ov-verified">—</div>
+          <div class="stat-label">Verified Proofs</div>
         </div>
-        <div class="card">
-          <h2>Traffic</h2>
-          <div id="traffic-panel" class="kv"></div>
+        <div class="card stat-box">
+          <div class="stat-value stat-accent" id="ov-peers">—</div>
+          <div class="stat-label">Unique Peers</div>
+        </div>
+        <div class="card stat-box">
+          <div class="stat-value stat-accent" id="ov-connections">—</div>
+          <div class="stat-label">Total Connections</div>
         </div>
       </section>
 
-      <section class="card">
+      <!-- Statement Verification Cards -->
+      <section class="card section-gap">
+        <h2>Statement Verification</h2>
+        <div class="statements" id="statement-cards"></div>
+      </section>
+
+      <!-- Timing Comparison Chart -->
+      <section class="card section-gap">
+        <h2>Timing Comparison</h2>
+        <div id="timing-chart" class="timing-chart">
+          <div class="empty-state">Run the demo to see timing data.</div>
+        </div>
+      </section>
+
+      <!-- Proof Exchange Summary -->
+      <section class="card section-gap">
         <h2>Proof Exchange Summary</h2>
-        <div id="proof-summary" class="kv"></div>
+        <div id="proof-summary" class="kv">
+          <div class="empty-state">No proof exchange summary available.</div>
+        </div>
       </section>
 
-      <section class="grid two-col">
+      <!-- Risk Score & Network -->
+      <section class="grid two-col section-gap">
+        <div class="card">
+          <h2>Risk Assessment</h2>
+          <div id="risk-panel">
+            <div class="empty-state">Awaiting verification results.</div>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Network Stats</h2>
+          <div id="traffic-panel" class="kv">
+            <div class="empty-state">No traffic data yet.</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Pin Result & Artifacts -->
+      <section class="grid two-col section-gap">
         <div class="card">
           <h2>Pin Result</h2>
-          <div id="pin-panel" class="kv"></div>
+          <div id="pin-panel" class="kv">
+            <div class="empty-state">No pin data yet.</div>
+          </div>
         </div>
         <div class="card">
           <h2>Artifacts</h2>
-          <div id="artifact-links" class="links"></div>
+          <div id="artifact-links" class="links">
+            <div class="empty-state">No run yet.</div>
+          </div>
         </div>
       </section>
 
-      <section class="card">
+      <!-- Logs -->
+      <section class="card section-gap">
         <h2>Logs</h2>
         <div class="log-controls" id="log-controls"></div>
         <pre id="log-viewer">No log selected.</pre>
       </section>
 
+      <!-- Run Metadata (collapsible) -->
       <section class="card">
-        <h2>Run Metadata</h2>
-        <pre id="run-json">No run yet.</pre>
+        <button class="collapse-toggle" id="metadata-toggle" type="button">
+          <span class="arrow">&#9654;</span> Run Metadata
+        </button>
+        <div class="collapsible-body" id="metadata-body">
+          <pre id="run-json" style="margin-top:12px">No run yet.</pre>
+        </div>
       </section>
+
     </main>
 
     <script src="/app.js"></script>

--- a/libp2p_privacy_poc/demo_web/static/index.html
+++ b/libp2p_privacy_poc/demo_web/static/index.html
@@ -28,6 +28,11 @@
         </div>
       </section>
 
+      <section class="card">
+        <h2>Proof Exchange Summary</h2>
+        <div id="proof-summary" class="kv"></div>
+      </section>
+
       <section class="grid two-col">
         <div class="card">
           <h2>Pin Result</h2>

--- a/libp2p_privacy_poc/demo_web/static/index.html
+++ b/libp2p_privacy_poc/demo_web/static/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy Protocol Toolkit - Demo Dashboard</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Privacy Protocol Toolkit Demo Dashboard</h1>
+      <p class="subtitle">
+        Step 1 skeleton is active. Run orchestration, API, and live cards are added in later steps.
+      </p>
+      <button id="run-btn" disabled>Run Full Demo (coming next step)</button>
+      <pre id="health"></pre>
+    </main>
+    <script src="/app.js"></script>
+  </body>
+</html>
+

--- a/libp2p_privacy_poc/demo_web/static/styles.css
+++ b/libp2p_privacy_poc/demo_web/static/styles.css
@@ -142,6 +142,25 @@ button:disabled {
   gap: 8px;
 }
 
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+  font-size: 0.9rem;
+}
+
+.summary-table th,
+.summary-table td {
+  border: 1px solid var(--border);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.summary-table th {
+  color: var(--muted);
+  background: #0b1a27;
+}
+
 .links {
   display: grid;
   gap: 6px;

--- a/libp2p_privacy_poc/demo_web/static/styles.css
+++ b/libp2p_privacy_poc/demo_web/static/styles.css
@@ -1,0 +1,38 @@
+body {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  background: #08111f;
+  color: #d4f7ff;
+}
+
+.container {
+  max-width: 960px;
+  margin: 40px auto;
+  padding: 24px;
+  border: 1px solid #17465a;
+  background: linear-gradient(180deg, #0a1a2f 0%, #091526 100%);
+}
+
+h1 {
+  margin-top: 0;
+}
+
+.subtitle {
+  color: #8bc0d3;
+}
+
+button {
+  padding: 10px 16px;
+  border: 1px solid #2b7da4;
+  background: #103349;
+  color: #d4f7ff;
+}
+
+pre {
+  margin-top: 20px;
+  padding: 12px;
+  border: 1px solid #17465a;
+  background: #050d18;
+  overflow-x: auto;
+}
+

--- a/libp2p_privacy_poc/demo_web/static/styles.css
+++ b/libp2p_privacy_poc/demo_web/static/styles.css
@@ -1,195 +1,876 @@
 :root {
-  --bg: #06111b;
-  --panel: #0d1f2e;
-  --panel-alt: #10283c;
-  --text: #d4f5ff;
-  --muted: #93b9ca;
-  --ok: #16c784;
-  --warn: #f6c343;
+  --bg: #070e17;
+  --surface: rgba(15, 25, 40, 0.85);
+  --surface-alt: rgba(20, 35, 55, 0.7);
+  --surface-hover: rgba(25, 45, 70, 0.6);
+  --text: #e4f0f8;
+  --text-secondary: #93b4c8;
+  --text-muted: #607d8f;
+  --accent: #3b9eff;
+  --accent-dim: rgba(59, 158, 255, 0.15);
+  --ok: #22c984;
+  --ok-dim: rgba(34, 201, 132, 0.12);
+  --warn: #f0b429;
+  --warn-dim: rgba(240, 180, 41, 0.12);
   --bad: #f05454;
-  --border: #1f4258;
+  --bad-dim: rgba(240, 84, 84, 0.12);
+  --border: rgba(60, 100, 140, 0.3);
+  --border-light: rgba(80, 130, 180, 0.15);
+  --radius: 12px;
+  --radius-sm: 8px;
+  --shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  --font: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "SF Mono", "Fira Code", "JetBrains Mono", "Cascadia Code", monospace;
+  --transition: 0.2s ease;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-  margin: 0;
-  font-family: "Segoe UI", Tahoma, sans-serif;
-  background: radial-gradient(circle at top right, #123552 0%, var(--bg) 55%);
+  font-family: var(--font);
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 60% at 10% 0%, rgba(30, 80, 140, 0.2) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 50% at 90% 100%, rgba(20, 60, 120, 0.15) 0%, transparent 50%);
   color: var(--text);
+  line-height: 1.55;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
 }
 
+/* ─── Layout ─── */
+
 .container {
-  max-width: 1200px;
-  margin: 24px auto;
-  padding: 20px;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px 28px 48px;
 }
+
+/* ─── Header ─── */
 
 .topbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar-brand {
+  display: flex;
+  align-items: center;
   gap: 12px;
-  margin-bottom: 12px;
 }
 
-h1,
-h2 {
-  margin: 0;
+.topbar-logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--accent) 0%, #6c5ce7 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+h1 span {
+  color: var(--text-secondary);
+  font-weight: 400;
 }
 
 h2 {
-  font-size: 1rem;
-  margin-bottom: 10px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin-bottom: 14px;
 }
+
+/* ─── Buttons ─── */
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  background: linear-gradient(135deg, #3b9eff 0%, #2b7ee0 100%);
+  color: #fff;
+  padding: 10px 22px;
+  border-radius: var(--radius-sm);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition);
+  box-shadow: 0 2px 8px rgba(59, 158, 255, 0.25);
+  white-space: nowrap;
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(59, 158, 255, 0.35);
+}
+
+.btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button {
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text);
+  padding: 7px 14px;
+  border-radius: var(--radius-sm);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition);
+  font-family: var(--font);
+}
+
+button:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ─── Cards ─── */
 
 .card {
+  background: var(--surface);
   border: 1px solid var(--border);
-  background: linear-gradient(180deg, var(--panel) 0%, #0a1824 100%);
-  border-radius: 8px;
-  padding: 12px;
+  border-radius: var(--radius);
+  padding: 20px;
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+  transition: border-color var(--transition);
 }
 
+.card + .card {
+  margin-top: 0;
+}
+
+/* ─── Banner ─── */
+
 .banner {
-  margin-bottom: 12px;
+  margin-bottom: 24px;
   font-weight: 600;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 20px;
+}
+
+.banner::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .banner-ready {
-  border-color: #2b5f79;
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+.banner-ready::before {
+  background: var(--text-muted);
 }
 
 .banner-running {
   border-color: var(--warn);
+  background: var(--warn-dim);
+  color: var(--warn);
+}
+
+.banner-running::before {
+  background: var(--warn);
+  animation: pulse-dot 1.2s ease infinite;
 }
 
 .banner-success {
   border-color: var(--ok);
+  background: var(--ok-dim);
+  color: var(--ok);
+}
+
+.banner-success::before {
+  background: var(--ok);
 }
 
 .banner-fallback {
   border-color: var(--warn);
+  background: var(--warn-dim);
+  color: var(--warn);
+}
+
+.banner-fallback::before {
+  background: var(--warn);
 }
 
 .banner-failed {
   border-color: var(--bad);
+  background: var(--bad-dim);
+  color: var(--bad);
 }
+
+.banner-failed::before {
+  background: var(--bad);
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* ─── Grid ─── */
 
 .grid {
   display: grid;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: 16px;
+  margin-bottom: 20px;
 }
 
 .two-col {
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
 }
 
-button {
-  border: 1px solid #2a7398;
-  background: linear-gradient(180deg, #1a4560 0%, #123246 100%);
-  color: var(--text);
-  padding: 8px 12px;
-  border-radius: 6px;
-  cursor: pointer;
+.three-col {
+  grid-template-columns: repeat(3, 1fr);
 }
 
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.overview-row {
+  grid-template-columns: 1fr 1fr 1fr;
 }
+
+/* ─── Overview Stat Boxes ─── */
+
+.stat-box {
+  text-align: center;
+  padding: 18px 16px;
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-label {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-ok { color: var(--ok); }
+.stat-warn { color: var(--warn); }
+.stat-bad { color: var(--bad); }
+.stat-accent { color: var(--accent); }
+
+/* ─── Risk Meter ─── */
+
+.risk-meter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.risk-arc {
+  position: relative;
+  width: 80px;
+  height: 44px;
+  overflow: hidden;
+}
+
+.risk-arc svg {
+  width: 80px;
+  height: 80px;
+  transform: rotate(-90deg);
+}
+
+.risk-arc-bg {
+  fill: none;
+  stroke: rgba(60, 100, 140, 0.2);
+  stroke-width: 8;
+}
+
+.risk-arc-fill {
+  fill: none;
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.6s ease, stroke 0.3s ease;
+}
+
+.risk-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+/* ─── Mini Bar (inline stat chart) ─── */
+
+.mini-bar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.mini-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+}
+
+.mini-bar-label {
+  width: 110px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.mini-bar-track {
+  flex: 1;
+  height: 6px;
+  background: rgba(60, 100, 140, 0.15);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.mini-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.5s ease;
+  min-width: 2px;
+}
+
+.mini-bar-value {
+  width: 70px;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Statement Cards ─── */
 
 .statements {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
 }
 
 .statement {
   border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--panel-alt);
-  padding: 8px;
+  border-radius: var(--radius);
+  background: var(--surface-alt);
+  padding: 16px;
+  transition: all var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.statement::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  border-radius: var(--radius) var(--radius) 0 0;
+  transition: background var(--transition);
+}
+
+.statement.verified::before {
+  background: var(--ok);
+}
+
+.statement.not-verified::before {
+  background: var(--bad);
+}
+
+.statement-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
 }
 
 .statement-title {
   font-weight: 600;
-  margin-bottom: 6px;
+  font-size: 0.95rem;
+  color: var(--text);
+  word-break: break-word;
 }
 
-.statement-status {
+.statement-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
   font-weight: 600;
-  margin-bottom: 4px;
+  padding: 3px 10px;
+  border-radius: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
-.statement-status.ok {
+.badge-ok {
+  background: var(--ok-dim);
   color: var(--ok);
+  border: 1px solid rgba(34, 201, 132, 0.25);
 }
 
-.statement-status.bad {
+.badge-bad {
+  background: var(--bad-dim);
   color: var(--bad);
+  border: 1px solid rgba(240, 84, 84, 0.25);
 }
 
-.statement-meta {
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-.kv {
+.statement-meta-grid {
   display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 8px;
 }
 
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.meta-key {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.meta-val {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--mono);
+}
+
+/* ─── Timing Chart ─── */
+
+.timing-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.timing-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  align-items: center;
+}
+
+.timing-label {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  text-align: right;
+  font-weight: 500;
+}
+
+.timing-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.timing-bar-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 18px;
+}
+
+.timing-bar-track {
+  flex: 1;
+  height: 10px;
+  background: rgba(60, 100, 140, 0.1);
+  border-radius: 5px;
+  overflow: hidden;
+  position: relative;
+}
+
+.timing-bar {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 0.6s ease;
+  min-width: 3px;
+}
+
+.timing-bar.verify-bar {
+  background: linear-gradient(90deg, #3b9eff, #6c5ce7);
+}
+
+.timing-bar.exchange-bar {
+  background: linear-gradient(90deg, #22c984, #0fbcf9);
+}
+
+.timing-bar-ms {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  min-width: 56px;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.timing-legend {
+  display: flex;
+  gap: 20px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.timing-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.timing-legend-swatch {
+  width: 12px;
+  height: 4px;
+  border-radius: 2px;
+}
+
+.swatch-verify {
+  background: linear-gradient(90deg, #3b9eff, #6c5ce7);
+}
+
+.swatch-exchange {
+  background: linear-gradient(90deg, #22c984, #0fbcf9);
+}
+
+/* ─── Summary Table ─── */
+
 .summary-table {
   width: 100%;
-  border-collapse: collapse;
-  margin-top: 10px;
-  font-size: 0.9rem;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-top: 12px;
+  font-size: 0.84rem;
 }
 
 .summary-table th,
 .summary-table td {
-  border: 1px solid var(--border);
-  padding: 6px 8px;
+  padding: 10px 12px;
   text-align: left;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .summary-table th {
-  color: var(--muted);
-  background: #0b1a27;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(10, 20, 35, 0.5);
 }
 
+.summary-table th:first-child {
+  border-radius: var(--radius-sm) 0 0 0;
+}
+
+.summary-table th:last-child {
+  border-radius: 0 var(--radius-sm) 0 0;
+}
+
+.summary-table tr:last-child td {
+  border-bottom: none;
+}
+
+.summary-table td {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.82rem;
+}
+
+.summary-table .cell-ok {
+  color: var(--ok);
+}
+
+.summary-table .cell-bad {
+  color: var(--bad);
+}
+
+/* ─── KV Panel ─── */
+
+.kv {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kv-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-light);
+  font-size: 0.88rem;
+}
+
+.kv-row:last-child {
+  border-bottom: none;
+}
+
+.kv-key {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.kv-val {
+  color: var(--text);
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.protocol-tag {
+  display: inline-block;
+  padding: 2px 10px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  font-family: var(--mono);
+}
+
+.peer-addr {
+  font-size: 0.78rem;
+  word-break: break-all;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+/* ─── Links ─── */
+
 .links {
-  display: grid;
-  gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .links a {
-  color: #86d8ff;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent);
   text-decoration: none;
+  font-size: 0.84rem;
+  font-weight: 500;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-alt);
+  transition: all var(--transition);
 }
 
 .links a:hover {
-  text-decoration: underline;
+  border-color: var(--accent);
+  background: var(--accent-dim);
 }
+
+/* ─── Logs ─── */
 
 .log-controls {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
+}
+
+.log-controls button.active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 pre {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px;
-  background: #050d15;
-  max-height: 320px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  padding: 14px;
+  background: rgba(5, 10, 18, 0.7);
+  max-height: 360px;
   overflow-y: auto;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+/* ─── Section Spacing ─── */
+
+.section-gap {
+  margin-bottom: 20px;
+}
+
+/* ─── Collapsible ─── */
+
+.collapse-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  padding: 0;
+  font-size: 0.82rem;
+  cursor: pointer;
+  font-family: var(--font);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.collapse-toggle:hover {
+  color: var(--text);
+  background: none;
+  border: none;
+}
+
+.collapse-toggle .arrow {
+  transition: transform var(--transition);
+  font-size: 0.7rem;
+}
+
+.collapse-toggle.open .arrow {
+  transform: rotate(90deg);
+}
+
+.collapsible-body {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+}
+
+.collapsible-body.open {
+  max-height: 2000px;
+}
+
+/* ─── Empty States ─── */
+
+.empty-state {
+  text-align: center;
+  padding: 24px 16px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 900px) {
+  .container {
+    padding: 16px;
+  }
+
+  .two-col,
+  .three-col,
+  .overview-row {
+    grid-template-columns: 1fr;
+  }
+
+  .statements {
+    grid-template-columns: 1fr;
+  }
+
+  .timing-row {
+    grid-template-columns: 100px 1fr;
+  }
+
+  h1 {
+    font-size: 1.1rem;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+}
+
+@media (max-width: 600px) {
+  .statement-meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timing-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .timing-label {
+    text-align: left;
+  }
+}
+
+/* ─── Scrollbar ─── */
+
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(60, 100, 140, 0.3);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(60, 100, 140, 0.5);
 }

--- a/libp2p_privacy_poc/demo_web/static/styles.css
+++ b/libp2p_privacy_poc/demo_web/static/styles.css
@@ -1,38 +1,176 @@
+:root {
+  --bg: #06111b;
+  --panel: #0d1f2e;
+  --panel-alt: #10283c;
+  --text: #d4f5ff;
+  --muted: #93b9ca;
+  --ok: #16c784;
+  --warn: #f6c343;
+  --bad: #f05454;
+  --border: #1f4258;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: "Segoe UI", Tahoma, sans-serif;
-  background: #08111f;
-  color: #d4f7ff;
+  background: radial-gradient(circle at top right, #123552 0%, var(--bg) 55%);
+  color: var(--text);
 }
 
 .container {
-  max-width: 960px;
-  margin: 40px auto;
-  padding: 24px;
-  border: 1px solid #17465a;
-  background: linear-gradient(180deg, #0a1a2f 0%, #091526 100%);
+  max-width: 1200px;
+  margin: 24px auto;
+  padding: 20px;
 }
 
-h1 {
-  margin-top: 0;
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
 }
 
-.subtitle {
-  color: #8bc0d3;
+h1,
+h2 {
+  margin: 0;
+}
+
+h2 {
+  font-size: 1rem;
+  margin-bottom: 10px;
+}
+
+.card {
+  border: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--panel) 0%, #0a1824 100%);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.banner {
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+
+.banner-ready {
+  border-color: #2b5f79;
+}
+
+.banner-running {
+  border-color: var(--warn);
+}
+
+.banner-success {
+  border-color: var(--ok);
+}
+
+.banner-fallback {
+  border-color: var(--warn);
+}
+
+.banner-failed {
+  border-color: var(--bad);
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.two-col {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 button {
-  padding: 10px 16px;
-  border: 1px solid #2b7da4;
-  background: #103349;
-  color: #d4f7ff;
+  border: 1px solid #2a7398;
+  background: linear-gradient(180deg, #1a4560 0%, #123246 100%);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.statements {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.statement {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-alt);
+  padding: 8px;
+}
+
+.statement-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.statement-status {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.statement-status.ok {
+  color: var(--ok);
+}
+
+.statement-status.bad {
+  color: var(--bad);
+}
+
+.statement-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.kv {
+  display: grid;
+  gap: 8px;
+}
+
+.links {
+  display: grid;
+  gap: 6px;
+}
+
+.links a {
+  color: #86d8ff;
+  text-decoration: none;
+}
+
+.links a:hover {
+  text-decoration: underline;
+}
+
+.log-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 pre {
-  margin-top: 20px;
-  padding: 12px;
-  border: 1px solid #17465a;
-  background: #050d18;
-  overflow-x: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+  background: #050d15;
+  max-height: 320px;
+  overflow-y: auto;
 }
-

--- a/libp2p_privacy_poc/tests/test_demo_web_integration.py
+++ b/libp2p_privacy_poc/tests/test_demo_web_integration.py
@@ -1,0 +1,121 @@
+"""Opt-in integration tests for demo web flow and sponsor pin flow."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from libp2p_privacy_poc import cli
+from libp2p_privacy_poc.demo_web.models import DemoWebConfig
+from libp2p_privacy_poc.demo_web.runner import DemoRunner
+
+
+def _find_repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "privacy_circuits").is_dir():
+            return parent
+    raise RuntimeError("repo root not found")
+
+
+def _port_is_available(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+@pytest.mark.network
+def test_demo_runner_network_smoke() -> None:
+    if os.environ.get("RUN_NETWORK_TESTS") != "1":
+        pytest.skip("RUN_NETWORK_TESTS not set")
+    pytest.importorskip("libp2p")
+
+    if not _port_is_available(50140) or not _port_is_available(50158):
+        pytest.skip("demo runner fixed ports 50140/50158 are busy")
+
+    repo_root = _find_repo_root()
+    assets_dir = repo_root / "privacy_circuits" / "params"
+    if not assets_dir.is_dir():
+        pytest.skip("privacy_circuits/params not available")
+
+    cfg = DemoWebConfig(
+        host="127.0.0.1",
+        port=8080,
+        assets_dir=str(assets_dir),
+        analyze_duration=10,
+        zk_timeout=60,
+        traffic_nodes=8,
+        pin_mode="mock",
+        log_level="warning",
+    )
+    runner = DemoRunner(cfg, root_dir=repo_root)
+    summary = runner.run_full_demo()
+
+    assert summary["status"] in {"success", "fallback"}
+    assert Path(summary["artifacts"]["report_json"]).exists()
+    assert summary["pin"]["backend_used"] == "mock"
+
+
+@pytest.mark.pin
+def test_pin_cli_all_statements_live_roundtrip() -> None:
+    if os.environ.get("RUN_PIN_TESTS") != "1":
+        pytest.skip("RUN_PIN_TESTS not set")
+
+    endpoint = os.environ.get("FILECOIN_PIN_ENDPOINT")
+    token = os.environ.get("FILECOIN_PIN_TOKEN")
+    if not endpoint or not token:
+        pytest.skip(
+            "FILECOIN_PIN_ENDPOINT and FILECOIN_PIN_TOKEN are required for pin tests"
+        )
+
+    repo_root = _find_repo_root()
+    assets_dir = repo_root / "privacy_circuits" / "params"
+    if not assets_dir.is_dir():
+        pytest.skip("privacy_circuits/params not available")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "pin-proof-record",
+            "--statement",
+            "all",
+            "--assets-dir",
+            str(assets_dir),
+            "--prove-mode",
+            "real",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    records = payload.get("results", [])
+    assert len(records) == 3
+
+    cids = [item.get("cid") for item in records if item.get("cid")]
+    assert len(cids) == 3
+
+    for cid in cids:
+        fetch_result = runner.invoke(
+            cli.main,
+            [
+                "fetch-proof-record",
+                "--cid",
+                cid,
+                "--recheck-assets-dir",
+                str(assets_dir),
+                "--json",
+            ],
+        )
+        assert fetch_result.exit_code == 0
+        fetch_payload = json.loads(fetch_result.output)
+        assert fetch_payload["recheck"]["ok"] is True

--- a/libp2p_privacy_poc/tests/test_demo_web_runner.py
+++ b/libp2p_privacy_poc/tests/test_demo_web_runner.py
@@ -58,7 +58,13 @@ def test_runner_command_building_and_sequence(tmp_path: Path) -> None:
         root_dir=tmp_path,
         python_executable="/tmp/fake-python",
     )
-    assert runner.planned_step_names() == ("zk-serve", "analyze", "zk-dial")
+    assert runner.planned_step_names() == (
+        "zk-serve",
+        "analyze",
+        "zk-dial",
+        "pin-proof-record",
+        "fetch-proof-record",
+    )
 
     serve_cmd = runner._build_zk_serve_cmd()
     assert serve_cmd[:3] == ["/tmp/fake-python", "-m", "libp2p_privacy_poc.cli"]
@@ -80,6 +86,19 @@ def test_runner_command_building_and_sequence(tmp_path: Path) -> None:
     assert "--count" in dial_cmd
     assert "12" in dial_cmd
     assert "--peer" in dial_cmd
+
+    pin_cmd = runner._build_pin_proof_record_cmd(
+        "/ip4/127.0.0.1/tcp/50140/p2p/QmServer"
+    )
+    assert "pin-proof-record" in pin_cmd
+    assert "--statement" in pin_cmd
+    assert "all" in pin_cmd
+    assert "--json" in pin_cmd
+
+    fetch_cmd = runner._build_fetch_proof_record_cmd("bafy-test")
+    assert "fetch-proof-record" in fetch_cmd
+    assert "--cid" in fetch_cmd
+    assert "--recheck-assets-dir" in fetch_cmd
 
 
 def test_runner_fails_when_server_multiaddr_missing(monkeypatch, tmp_path: Path) -> None:
@@ -114,3 +133,164 @@ def test_runner_fails_when_server_multiaddr_missing(monkeypatch, tmp_path: Path)
     assert "failed to parse server multiaddr" in result["message"]
     assert Path(result["artifacts"]["summary_json"]).exists()
 
+
+def test_pin_mode_prefer_live_falls_back_to_mock(monkeypatch, tmp_path: Path) -> None:
+    runner = DemoRunner(
+        _config(),
+        root_dir=tmp_path,
+        python_executable="/tmp/fake-python",
+    )
+    artifacts = runner._create_run_artifacts("run-fallback")
+    calls = []
+
+    def _fake_backend(*, backend, artifacts, server_multiaddr):
+        calls.append(backend)
+        if backend == "live":
+            return {
+                "backend_used": "live",
+                "error": "live unavailable",
+                "pin_exit_code": None,
+                "fetch_exit_codes": {},
+                "pin_results": [],
+                "fetch_results": [],
+            }
+        return {
+            "backend_used": "mock",
+            "error": None,
+            "pin_exit_code": 0,
+            "fetch_exit_codes": {"bafy-mock": 0},
+            "pin_results": [
+                {
+                    "statement": "membership",
+                    "schema": 2,
+                    "depth": 16,
+                    "verify_ok": True,
+                    "cid": "bafy-mock",
+                    "error": None,
+                }
+            ],
+            "fetch_results": [
+                {
+                    "cid": "bafy-mock",
+                    "statement": "membership",
+                    "exit_code": 0,
+                    "recheck_ok": True,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(runner, "_run_pin_backend", _fake_backend)
+    result = runner._run_pin_flow(
+        artifacts,
+        "/ip4/127.0.0.1/tcp/50140/p2p/QmServer",
+    )
+
+    assert calls == ["live", "mock"]
+    assert result["mode_requested"] == "prefer-live"
+    assert result["backend_used"] == "mock"
+    assert result["fell_back_to_mock"] is True
+    assert result["live_error"] == "live unavailable"
+    assert result["error"] is None
+
+
+def test_pin_mode_live_is_strict(monkeypatch, tmp_path: Path) -> None:
+    cfg = DemoWebConfig(
+        **{**_config().as_dict(), "pin_mode": "live"}
+    )
+    runner = DemoRunner(
+        cfg,
+        root_dir=tmp_path,
+        python_executable="/tmp/fake-python",
+    )
+    artifacts = runner._create_run_artifacts("run-live")
+    calls = []
+
+    def _fake_backend(*, backend, artifacts, server_multiaddr):
+        calls.append(backend)
+        return {
+            "backend_used": backend,
+            "error": "missing FILECOIN_PIN_ENDPOINT",
+            "pin_exit_code": None,
+            "fetch_exit_codes": {},
+            "pin_results": [],
+            "fetch_results": [],
+        }
+
+    monkeypatch.setattr(runner, "_run_pin_backend", _fake_backend)
+    result = runner._run_pin_flow(
+        artifacts,
+        "/ip4/127.0.0.1/tcp/50140/p2p/QmServer",
+    )
+
+    assert calls == ["live"]
+    assert result["mode_requested"] == "live"
+    assert result["fell_back_to_mock"] is False
+    assert result["error"] == "missing FILECOIN_PIN_ENDPOINT"
+
+
+def test_run_pin_backend_mock_roundtrip_path(monkeypatch, tmp_path: Path) -> None:
+    runner = DemoRunner(
+        _config(),
+        root_dir=tmp_path,
+        python_executable="/tmp/fake-python",
+    )
+    artifacts = runner._create_run_artifacts("run-mock")
+    captured = {"endpoint": None, "token": None}
+    mock_server_state = {"started": False, "stopped": False}
+
+    class _FakePinMockServer:
+        token = "demo-web-mock-token"
+        endpoint = "http://127.0.0.1:8899"
+
+        def start(self) -> None:
+            mock_server_state["started"] = True
+
+        def stop(self) -> None:
+            mock_server_state["stopped"] = True
+
+    monkeypatch.setattr(
+        "libp2p_privacy_poc.demo_web.runner.PinMockServer",
+        _FakePinMockServer,
+    )
+
+    def _fake_run_json(cmd, *, log_path, env, timeout_seconds, append):
+        if "pin-proof-record" in cmd:
+            captured["endpoint"] = env.get("FILECOIN_PIN_ENDPOINT")
+            captured["token"] = env.get("FILECOIN_PIN_TOKEN")
+            return (
+                {
+                    "results": [
+                        {
+                            "statement": "membership",
+                            "schema": 2,
+                            "depth": 16,
+                            "verify_ok": True,
+                            "cid": "bafy-mock",
+                            "error": None,
+                        }
+                    ]
+                },
+                0,
+            )
+        if "fetch-proof-record" in cmd:
+            assert env.get("FILECOIN_PIN_ENDPOINT") == captured["endpoint"]
+            return ({"cid": "bafy-mock", "recheck": {"ok": True}}, 0)
+        raise AssertionError("unexpected command")
+
+    monkeypatch.setattr(runner, "_run_json_command", _fake_run_json)
+    result = runner._run_pin_backend(
+        backend="mock",
+        artifacts=artifacts,
+        server_multiaddr="/ip4/127.0.0.1/tcp/50140/p2p/QmServer",
+    )
+
+    assert result["backend_used"] == "mock"
+    assert result["error"] is None
+    assert result["pin_exit_code"] == 0
+    assert result["fetch_exit_codes"]["bafy-mock"] == 0
+    assert result["fetch_results"][0]["recheck_ok"] is True
+    assert isinstance(captured["endpoint"], str)
+    assert captured["endpoint"] == "http://127.0.0.1:8899"
+    assert captured["token"] == "demo-web-mock-token"
+    assert mock_server_state["started"] is True
+    assert mock_server_state["stopped"] is True

--- a/libp2p_privacy_poc/tests/test_demo_web_runner.py
+++ b/libp2p_privacy_poc/tests/test_demo_web_runner.py
@@ -1,0 +1,116 @@
+"""Unit tests for demo web runner orchestration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from libp2p_privacy_poc.demo_web.models import DemoWebConfig
+from libp2p_privacy_poc.demo_web.runner import (
+    DemoRunner,
+    classify_run_status,
+    extract_analyzer_multiaddr,
+    extract_server_multiaddr,
+)
+
+
+def _config() -> DemoWebConfig:
+    return DemoWebConfig(
+        host="127.0.0.1",
+        port=8080,
+        assets_dir="privacy_circuits/params",
+        analyze_duration=20,
+        zk_timeout=120,
+        traffic_nodes=12,
+        pin_mode="prefer-live",
+        log_level="warning",
+    )
+
+
+def test_extract_server_multiaddr() -> None:
+    text = (
+        "Peer ID: QmServer\n"
+        "Listening: /ip4/127.0.0.1/tcp/50140/p2p/QmServer\n"
+        "Serving privacyzk protocol.\n"
+    )
+    assert (
+        extract_server_multiaddr(text)
+        == "/ip4/127.0.0.1/tcp/50140/p2p/QmServer"
+    )
+
+
+def test_extract_analyzer_multiaddr() -> None:
+    text = "✓ Listening on: /ip4/127.0.0.1/tcp/50158/p2p/QmAnalyzer\n"
+    assert (
+        extract_analyzer_multiaddr(text)
+        == "/ip4/127.0.0.1/tcp/50158/p2p/QmAnalyzer"
+    )
+
+
+def test_classify_run_status() -> None:
+    assert classify_run_status(core_error=False, fallback_detected=False)[0] == "success"
+    assert classify_run_status(core_error=False, fallback_detected=True)[0] == "fallback"
+    assert classify_run_status(core_error=True, fallback_detected=False)[0] == "failed"
+
+
+def test_runner_command_building_and_sequence(tmp_path: Path) -> None:
+    runner = DemoRunner(
+        _config(),
+        root_dir=tmp_path,
+        python_executable="/tmp/fake-python",
+    )
+    assert runner.planned_step_names() == ("zk-serve", "analyze", "zk-dial")
+
+    serve_cmd = runner._build_zk_serve_cmd()
+    assert serve_cmd[:3] == ["/tmp/fake-python", "-m", "libp2p_privacy_poc.cli"]
+    assert "zk-serve" in serve_cmd
+    assert "--prove-mode" in serve_cmd
+    assert "real" in serve_cmd
+
+    report_path = tmp_path / "demo_reports" / "web" / "r1" / "report.json"
+    analyze_cmd = runner._build_analyze_cmd(
+        "/ip4/127.0.0.1/tcp/50140/p2p/QmServer", report_path
+    )
+    assert "analyze" in analyze_cmd
+    assert "--zk-statement" in analyze_cmd
+    assert "all" in analyze_cmd
+    assert str(report_path) in analyze_cmd
+
+    dial_cmd = runner._build_zk_dial_cmd("/ip4/127.0.0.1/tcp/50158/p2p/QmAnalyzer")
+    assert "zk-dial" in dial_cmd
+    assert "--count" in dial_cmd
+    assert "12" in dial_cmd
+    assert "--peer" in dial_cmd
+
+
+def test_runner_fails_when_server_multiaddr_missing(monkeypatch, tmp_path: Path) -> None:
+    class _FakeProc:
+        def poll(self):
+            return 0
+
+        def wait(self, timeout=None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    runner = DemoRunner(
+        _config(),
+        root_dir=tmp_path,
+        python_executable="/tmp/fake-python",
+    )
+
+    monkeypatch.setattr(runner, "_start_process", lambda cmd, log_path: _FakeProc())
+    monkeypatch.setattr(
+        runner,
+        "_wait_for_server_multiaddr",
+        lambda log_path, timeout_seconds, process: None,
+    )
+
+    result = runner.run_full_demo()
+    assert result["status"] == "failed"
+    assert "failed to parse server multiaddr" in result["message"]
+    assert Path(result["artifacts"]["summary_json"]).exists()
+

--- a/libp2p_privacy_poc/tests/test_demo_web_server.py
+++ b/libp2p_privacy_poc/tests/test_demo_web_server.py
@@ -1,0 +1,160 @@
+"""Unit tests for demo web API/app contracts (socket-free)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from libp2p_privacy_poc.demo_web.models import DemoWebConfig
+from libp2p_privacy_poc.demo_web.server import DemoWebApp, match_run_api_path
+
+
+class _FakeRunner:
+    def __init__(self, base_dir: Path) -> None:
+        self._base_dir = base_dir
+
+    def run_full_demo(self):
+        run_id = "fake-run"
+        run_dir = self._base_dir / "demo_reports" / "web" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        server_log = run_dir / "zk_serve.log"
+        analyze_log = run_dir / "analyze.log"
+        dial_log = run_dir / "zk_dial.log"
+        pin_log = run_dir / "pin.log"
+        fetch_log = run_dir / "fetch.log"
+        report_json = run_dir / "report.json"
+        summary_json = run_dir / "summary.json"
+
+        server_log.write_text("server up\n", encoding="utf-8")
+        analyze_log.write_text("analysis done\n", encoding="utf-8")
+        dial_log.write_text("dial done\n", encoding="utf-8")
+        pin_log.write_text("pin ok\n", encoding="utf-8")
+        fetch_log.write_text("fetch ok\n", encoding="utf-8")
+
+        report_payload = {
+            "report_id": "demo-report",
+            "privacy_report": {
+                "statistics": {
+                    "unique_peers": 9,
+                    "total_connections": 12,
+                }
+            },
+            "snark_phase2b_proofs": [
+                {"statement": "membership_v2", "verified": True, "prove_mode": "real"},
+                {"statement": "continuity_v2", "verified": True, "prove_mode": "real"},
+                {"statement": "unlinkability_v2", "verified": True, "prove_mode": "real"},
+            ],
+        }
+        report_json.write_text(json.dumps(report_payload), encoding="utf-8")
+
+        summary = {
+            "run_id": run_id,
+            "status": "success",
+            "message": "Demo orchestration completed successfully.",
+            "pin": {
+                "mode_requested": "prefer-live",
+                "backend_used": "mock",
+                "fell_back_to_mock": True,
+                "pin_results": [
+                    {
+                        "statement": "membership",
+                        "schema": 2,
+                        "depth": 16,
+                        "verify_ok": True,
+                        "cid": "bafy-test",
+                        "error": None,
+                    }
+                ],
+            },
+            "artifacts": {
+                "run_dir": str(run_dir),
+                "server_log": str(server_log),
+                "analyze_log": str(analyze_log),
+                "dial_log": str(dial_log),
+                "pin_log": str(pin_log),
+                "fetch_log": str(fetch_log),
+                "report_json": str(report_json),
+                "summary_json": str(summary_json),
+            },
+        }
+        summary_json.write_text(json.dumps(summary), encoding="utf-8")
+        return summary
+
+
+def _config() -> DemoWebConfig:
+    return DemoWebConfig(
+        host="127.0.0.1",
+        port=8080,
+        assets_dir="privacy_circuits/params",
+        analyze_duration=20,
+        zk_timeout=120,
+        traffic_nodes=12,
+        pin_mode="prefer-live",
+        log_level="warning",
+    )
+
+
+def _wait_until_complete(app: DemoWebApp, run_id: str, timeout_s: float = 2.0):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        payload = app.get_run_payload(run_id)
+        assert payload is not None
+        if payload["status"] != "running":
+            return payload
+        time.sleep(0.01)
+    raise AssertionError("run did not finish in time")
+
+
+def test_match_run_api_path() -> None:
+    assert match_run_api_path("/api/runs/r1") == ("r1", "run", "")
+    assert match_run_api_path("/api/runs/r1/logs/analyze") == (
+        "r1",
+        "log",
+        "analyze",
+    )
+    assert match_run_api_path("/api/runs/r1/artifacts/report.json") == (
+        "r1",
+        "artifact",
+        "report.json",
+    )
+    assert match_run_api_path("/api/health") is None
+
+
+def test_demo_web_app_run_lifecycle_and_payload_contract(tmp_path: Path) -> None:
+    app = DemoWebApp(_config(), runner_factory=lambda: _FakeRunner(tmp_path))
+
+    started = app.start_run()
+    assert started["status"] == "running"
+    assert started["run_id"].startswith("web-")
+
+    payload = _wait_until_complete(app, started["run_id"])
+    assert payload["status"] == "success"
+    assert "summary" in payload
+    assert "report" in payload
+    assert payload["report"]["report_id"] == "demo-report"
+    assert len(payload["report"]["snark_phase2b_proofs"]) == 3
+
+
+def test_demo_web_app_resolve_logs_and_artifacts(tmp_path: Path) -> None:
+    app = DemoWebApp(_config(), runner_factory=lambda: _FakeRunner(tmp_path))
+    run_id = app.start_run()["run_id"]
+    _wait_until_complete(app, run_id)
+
+    analyze_log = app.resolve_log_path(run_id, "analyze")
+    assert analyze_log.read_text(encoding="utf-8") == "analysis done\n"
+
+    report_path = app.resolve_artifact_path(run_id, "report.json")
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["report_id"] == "demo-report"
+
+
+def test_demo_web_static_ui_contract() -> None:
+    static_dir = Path("libp2p_privacy_poc/demo_web/static")
+    index_html = (static_dir / "index.html").read_text(encoding="utf-8")
+    app_js = (static_dir / "app.js").read_text(encoding="utf-8")
+
+    assert "Run Full Demo" in index_html
+    assert "/api/runs" in app_js
+    assert "/api/runs/${currentRunId}/logs/" in app_js

--- a/libp2p_privacy_poc/tests/test_privacyzk_cli.py
+++ b/libp2p_privacy_poc/tests/test_privacyzk_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from click.testing import CliRunner
+import pytest
 
 from libp2p_privacy_poc import cli
 
@@ -34,3 +35,19 @@ def test_zk_verify_rejects_bad_depth() -> None:
         ],
     )
     assert result.exit_code != 0
+
+
+def test_demo_web_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["demo-web", "--help"])
+    assert result.exit_code == 0
+    assert "--traffic-nodes" in result.output
+    assert "--pin-mode" in result.output
+
+
+@pytest.mark.parametrize("count", [7, 14])
+def test_demo_web_rejects_traffic_nodes_out_of_range(count: int) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["demo-web", "--traffic-nodes", str(count)])
+    assert result.exit_code != 0
+    assert "traffic-nodes must be in range 8..13" in result.output


### PR DESCRIPTION
## Summary
- add the `demo-web` local dashboard and orchestration flow on top of the existing CLI
- add real-network run sequencing for `zk-serve`, `analyze --zk-statement all`, `zk-dial`, `pin-proof-record`, and `fetch-proof-record`
- add `prefer-live` / `live` / `mock` pin modes plus runner integration and artifact capture
- add the judge-facing dashboard UI for proof status, timings, risk/network stats, pin results, logs, and artifacts
- fix the risk panel to use analyzer risk score/level instead of proof-count heuristics
- add a concise architecture document with component and workflow diagrams

## Testing
- `PYTHONPATH=. ./venv/bin/python -m pytest -q libp2p_privacy_poc/tests/test_demo_web_server.py`
- `PYTHONPATH=. ./venv/bin/python -m pytest -q libp2p_privacy_poc/tests/test_demo_web_runner.py libp2p_privacy_poc/tests/test_privacyzk_cli.py`
- `PYTHONPATH=. ./venv/bin/python -m pytest -q libp2p_privacy_poc/tests/test_demo_web_server.py libp2p_privacy_poc/tests/test_demo_web_runner.py libp2p_privacy_poc/tests/test_demo_web_integration.py libp2p_privacy_poc/tests/test_privacyzk_cli.py`
- `PYTHONPATH=. ./venv/bin/python -m pytest -q -m network -rs` (gated; skips without `RUN_NETWORK_TESTS=1`)
- `PYTHONPATH=. ./venv/bin/python -m pytest -q -m pin -rs` (gated; skips without `RUN_PIN_TESTS=1`)

## Notes
- the dashboard remains an orchestration wrapper; CLI and protocol logic stay the source of truth
- pinning remains additive and opt-in; existing proof flows are unchanged unless the new commands are used